### PR TITLE
fix: redundant space in shell script

### DIFF
--- a/backend/setup.sh
+++ b/backend/setup.sh
@@ -1,3 +1,3 @@
 export BACKEND_SECRET_KEY="super-secret-key"
-export MYSQL_USER = "django"
-export MYSQL_PASSWORD = "djangopass"
+export MYSQL_USER="django"
+export MYSQL_PASSWORD="djangopass"


### PR DESCRIPTION
Fixed a minor thing in setup.sh script.

Space before and after `=` used to cause shell script to raise `bad assignment` warning. 