### PR TITLE
Feat/226 pagination control in the backend

### DIFF
--- a/backend/foods/tests.py
+++ b/backend/foods/tests.py
@@ -110,7 +110,6 @@ class FoodCatalogTests(TestCase):
         response = self.client.get(
             reverse("get_foods"), {"category": "NonexistentCategory"}
         )
-        print("Response data in test_nonexistent_category: ", response.data)
         self.assertEqual(response.status_code, status.HTTP_206_PARTIAL_CONTENT)
         self.assertEqual(
             response.data["warning"],

--- a/backend/foods/views.py
+++ b/backend/foods/views.py
@@ -47,7 +47,7 @@ class FoodCatalog(ListAPIView):
             if not categories:
                 self.empty = True
                 return FoodEntry.objects.none()
-        return queryset.filter(category__in=categories)
+        return queryset.filter(category__in=categories).order_by("id")
 
     def list(self, request, *args, **kwargs):
         self.empty = False

--- a/backend/foods/views.py
+++ b/backend/foods/views.py
@@ -4,39 +4,24 @@ from rest_framework.views import APIView
 from foods.models import FoodEntry
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from foods.serializers import FoodEntrySerializer
+from rest_framework.generics import ListAPIView
 
 
-class FoodCatalog(APIView):
+class FoodCatalog(ListAPIView):
     permission_classes = [AllowAny]
+    serializer_class = FoodEntrySerializer
 
-    def get(self, request):
-        """
-        GET /foods/get_foods
-        Fetch and return a list of food entries in the system.
-        Query parameters:
-        - limit: The maximum number of food entries to return. Default is 10.
-        - categories: List of categories to filter the food entries. If not provided, all available categories are used.
-        """
-        limit = request.query_params.get("limit", 10)
-        try:
-            limit = int(limit)
-        except ValueError:
-            return Response(
-                {"error": "Invalid limit parameter. Must be an integer."}, status=400
-            )
-
-        # FILTER BY CATEGORIES
+    def get_queryset(self):
+        queryset = FoodEntry.objects.all()
         available_categories = list(
             FoodEntry.objects.values_list("category", flat=True).distinct()
         )
         available_categories_lc = [cat.lower() for cat in available_categories]
 
-        # Accept both 'categories' and 'category' as query params
-        categories_param = request.query_params.get("categories", None)
+        categories_param = self.request.query_params.get("categories", None)
         if categories_param is None:
-            categories_param = request.query_params.get("category", "")
+            categories_param = self.request.query_params.get("category", "")
 
-        warning = None
         if categories_param == "":
             categories = available_categories
         else:
@@ -45,29 +30,11 @@ class FoodCatalog(APIView):
                 for category in categories_param.split(",")
                 if category.strip()
             ]
-            invalid_categories = [
-                cat
-                for cat in requested_categories
-                if cat not in available_categories_lc
-            ]
             categories = [
                 available_categories[i]
                 for i, cat in enumerate(available_categories_lc)
                 if cat in requested_categories
             ]
-            if invalid_categories:
-                warning = f"Some categories are not available: {', '.join(invalid_categories)}"
-            # If no valid categories, return empty list
             if not categories:
-                if warning:
-                    return Response({"warning": warning, "results": []}, status=206)
-                return Response([], status=200)
-
-        print("final Categories:", categories)
-        queryset = FoodEntry.objects.filter(category__in=categories)[:limit]
-        serializer = FoodEntrySerializer(queryset, many=True)
-        response_data = serializer.data
-        if warning:
-            # return 206 status code (Partial Content) with warning message
-            return Response({"warning": warning, "results": response_data}, status=206)
-        return Response(response_data, status=200)
+                return FoodEntry.objects.none()
+        return queryset.filter(category__in=categories)

--- a/backend/foods/views.py
+++ b/backend/foods/views.py
@@ -18,6 +18,8 @@ class FoodCatalog(ListAPIView):
         )
         available_categories_lc = [cat.lower() for cat in available_categories]
 
+        self.warning = None  # Store warning for use in list()
+
         categories_param = self.request.query_params.get("categories", None)
         if categories_param is None:
             categories_param = self.request.query_params.get("category", "")
@@ -35,6 +37,43 @@ class FoodCatalog(ListAPIView):
                 for i, cat in enumerate(available_categories_lc)
                 if cat in requested_categories
             ]
+            invalid_categories = [
+                cat
+                for cat in requested_categories
+                if cat not in available_categories_lc
+            ]
+            if invalid_categories:
+                self.warning = f"Some categories are not available: {', '.join(invalid_categories)}"
             if not categories:
+                self.empty = True
                 return FoodEntry.objects.none()
         return queryset.filter(category__in=categories)
+
+    def list(self, request, *args, **kwargs):
+        self.empty = False
+        queryset = self.filter_queryset(self.get_queryset())
+
+        page = self.paginate_queryset(queryset)
+        if hasattr(self, "empty") and self.empty:
+            # No valid categories, return warning and empty results
+            warning = getattr(self, "warning", None)
+            if warning:
+                return Response({"warning": warning, "results": []}, status=206)
+            return Response({"results": []}, status=200)
+
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            data = self.get_paginated_response(serializer.data).data
+        else:
+            serializer = self.get_serializer(queryset, many=True)
+            data = serializer.data
+
+        warning = getattr(self, "warning", None)
+        if warning:
+            # Add warning to paginated response
+            if isinstance(data, dict):
+                data["warning"] = warning
+            else:
+                data = {"warning": warning, "results": data}
+            return Response(data, status=206)
+        return Response(data)

--- a/backend/forum/tests/test_comment.py
+++ b/backend/forum/tests/test_comment.py
@@ -48,10 +48,10 @@ class CommentTests(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-        if data := response.data:
-            self.assertEqual(len(data), 2)
-            self.assertEqual(data[0]["body"], "First")
-            self.assertEqual(data[1]["body"], "Second")
+        if results := response.data.get("results"):
+            self.assertEqual(len(results), 2)
+            self.assertEqual(results[0]["body"], "First")
+            self.assertEqual(results[1]["body"], "Second")
 
     def test_user_can_delete_own_comment(self):
         comment = Comment.objects.create(

--- a/backend/forum/tests/test_tags.py
+++ b/backend/forum/tests/test_tags.py
@@ -55,7 +55,7 @@ class TaggingTests(TestCase):
         response = cast(Any, self.client.get(f"/forum/posts/?tags={self.tag1.id}"))
         self.assertEqual(response.status_code, 200)
 
-        titles = [p["title"] for p in response.data]
+        titles = [p["title"] for p in response.data["results"]]
         self.assertIn("Apple tips", titles)
         self.assertIn("Hybrid Post", titles)
         self.assertNotIn("Avocado toast", titles)
@@ -68,7 +68,7 @@ class TaggingTests(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-        titles = [p["title"] for p in response.data]
+        titles = [p["title"] for p in response.data["results"]]
         self.assertIn("Apple tips", titles)
         self.assertIn("Avocado toast", titles)
         self.assertIn("Hybrid Post", titles)
@@ -77,11 +77,11 @@ class TaggingTests(TestCase):
         # ascending
         response = cast(Any, self.client.get("/forum/posts/?ordering=created_at"))
         self.assertEqual(response.status_code, 200)
-        ordered_titles = [p["title"] for p in response.data]
+        ordered_titles = [p["title"] for p in response.data["results"]]
         self.assertEqual(ordered_titles, ["Apple tips", "Avocado toast", "Hybrid Post"])
 
         # descending
         response = cast(Any, self.client.get("/forum/posts/?ordering=-created_at"))
         self.assertEqual(response.status_code, 200)
-        ordered_titles = [p["title"] for p in response.data]
+        ordered_titles = [p["title"] for p in response.data["results"]]
         self.assertEqual(ordered_titles, ["Hybrid Post", "Avocado toast", "Apple tips"])

--- a/backend/project/settings.py
+++ b/backend/project/settings.py
@@ -157,9 +157,8 @@ REST_FRAMEWORK = {
         "rest_framework_simplejwt.authentication.JWTAuthentication",
     ),
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
-    # TODO: disabling pagination for now, as current tests are not compatible with it
-    # "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
-    # "PAGE_SIZE": 10,
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 10,
 }
 
 SIMPLE_JWT = {


### PR DESCRIPTION

# PR: Backend Pagination Control & Test Updates

## Summary

This PR introduces backend pagination control for the foods and forum endpoints, and updates related test cases to ensure correct behavior with paginated responses.

---

## Changes

- Activated and fixed pagination for food and forum endpoints.
- Updated test cases to work with paginated responses.
- Ensured correct HTTP status codes are returned for paginated and warning responses.
- Refactored views to avoid overriding methods that break pagination.

---

## Co-Authors

- @hasacankeles
- @ArdaSaygan 
---

## How to Test

1. Run the backend test suite:
   ```sh
   python manage.py test
   ```
2. Query paginated endpoints (e.g., `/foods/?page=10`) and verify paginated responses.
3. Ensure warnings and status codes are handled as expected for invalid queries.

---

**Closes #226** 