### PR TITLE
fix: food catalog not shown

### DIFF
--- a/frontend/src/pages/foods/Foods.tsx
+++ b/frontend/src/pages/foods/Foods.tsx
@@ -40,7 +40,7 @@ const Foods = () => {
     const fetchFoods = async () => {
         try {
             const response = await apiClient.getFoods();
-            setFoods(response);
+            setFoods(response.results); // response is now a paginated response (count, next, previous, results)
             setFetchSuccess(true);
             console.log("Fetched foods:", response);
         } catch (error) {


### PR DESCRIPTION
The errors raises due to recent pagination PRs, since responses are now a four tuple `(count, next, previous, results)`, and the real data is in the `results`. I fixed the issue for now, however, there is still type conflicts. These should be resolved in a future PR where we resolve type errors.