### PR TITLE
Mobile APK Generation

### DIFF
--- a/mobile/nutrihub/app.json
+++ b/mobile/nutrihub/app.json
@@ -19,10 +19,16 @@
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
-      }
+      },
+      "package": "com.y4z1c1.nutrihub"
     },
     "web": {
       "favicon": "./assets/favicon.png"
+    },
+    "extra": {
+      "eas": {
+        "projectId": "082f0add-9ca4-42a3-9133-e8b160fa4c7f"
+      }
     }
   }
 }

--- a/mobile/nutrihub/eas.json
+++ b/mobile/nutrihub/eas.json
@@ -1,0 +1,18 @@
+{
+  "build": {
+    "preview": {
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "preview2": {
+      "android": {
+        "gradleCommand": ":app:assembleRelease"
+      }
+    },
+    "preview3": {
+      "developmentClient": true
+    },
+    "production": {}
+  }
+} 


### PR DESCRIPTION
# NutriHub Mobile App - APK Generation

## Overview
This PR adds configuration for generating Android APK files for the NutriHub mobile application.

## Changes
- Added `eas.json` configuration file for EAS Build
- Updated build profiles for Android APK generation
- Documented APK build process

## APK Generation Instructions

### Prerequisites
- Expo account
- EAS CLI installed (`npm install -g eas-cli`)

### Account Configuration
**IMPORTANT**: The current configuration is linked to the `y4z1c1` Expo account. Before building:

1. Create your own Expo account if you don't have one: [https://expo.dev/signup](https://expo.dev/signup)
2. Configure EAS with your account:
```bash
eas login
```
3. Update project configuration to use your account:
```bash
eas update:configure
```

### Server-Based Build (EAS)
1. Navigate to the project directory:
```bash
cd mobile/nutrihub
```

2. Build the APK using Expo's build servers:
```bash
eas build -p android --profile preview
```

3. Follow the link provided after build completion to download the APK file.

## Important Notes
- Before building, ensure the development BASE_URL in `src/config/index.ts` is configured properly
- For development testing, add your public IP to the BASE_URL
- The build process runs on Expo's servers - no local Android setup required
- First-time builds may take longer (10-15 minutes)

## Generated Files
- `eas.json`: Configuration for EAS builds
- Android APK file (generated and downloadable from Expo servers) 

<img width="1202" alt="image" src="https://github.com/user-attachments/assets/37a3f66b-1d41-4fbb-8d85-f2766f4f857b" />
