### PR TITLE
Refactor all absolute endpoint usages with reverse calls

### DIFF
--- a/backend/accounts/tests/test_changePassword.py
+++ b/backend/accounts/tests/test_changePassword.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from django.urls import reverse
 from rest_framework.test import APITestCase, APIClient
 from rest_framework import status
 from rest_framework_simplejwt.tokens import RefreshToken
@@ -24,7 +25,7 @@ class ChangePasswordTests(APITestCase):
             HTTP_AUTHORIZATION=f"Bearer {str(refresh.access_token)}"
         )
 
-        self.url = "/users/change-password/"
+        self.url = reverse("change-password")
 
     def test_change_password_success(self):
         """

--- a/backend/accounts/tests/test_logoutView.py
+++ b/backend/accounts/tests/test_logoutView.py
@@ -13,7 +13,7 @@ class LogoutViewTests(APITestCase):
         self.refresh = RefreshToken.for_user(self.user)
         self.access_token = str(self.refresh.access_token)
         self.refresh_token = str(self.refresh)
-        self.url = "/users/token/logout/"
+        self.url = reverse("token_logout")
 
     def test_logout_successful(self):
         self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.access_token}")

--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -1,11 +1,13 @@
 from typing import cast
 from django.http import HttpResponse
 from django.test import TestCase
+from django.urls import reverse
 
 
 class GetTimeTest(TestCase):
     def test_get_time_success(self):
-        response = cast(HttpResponse, self.client.get("/api/time?name=Arda"))
+        url = reverse("get-time") + "?name=Arda"
+        response = cast(HttpResponse, self.client.get(url))
         self.assertEqual(response.status_code, 200)
         self.assertIn("time", response.json())  # type: ignore
         self.assertEqual(response.json()["name"], "Arda")  # type:ignore

--- a/backend/forum/tests/test_posts.py
+++ b/backend/forum/tests/test_posts.py
@@ -1,6 +1,7 @@
 from typing import cast
 from django.test import TestCase
 from django.contrib.auth import get_user_model
+from django.urls import reverse
 from rest_framework.test import APIClient
 from rest_framework.views import Response
 
@@ -22,10 +23,11 @@ class PostTests(TestCase):
 
     def test_create_post(self):
         self.client.force_authenticate(user=self.user1)
+        url = reverse("post-list")
         response = cast(
             Response,
             self.client.post(
-                "/forum/posts/", {"title": "First Post", "body": "This is a test post"}
+                url, {"title": "First Post", "body": "This is a test post"}
             ),
         )
         self.assertEqual(response.status_code, 201)
@@ -35,18 +37,18 @@ class PostTests(TestCase):
     def test_author_can_delete_own_post(self):
         post = Post.objects.create(title="Delete Me", body="...", author=self.user1)
         self.client.force_authenticate(user=self.user1)
-        response = cast(Response, self.client.delete(f"/forum/posts/{post.id}/"))
+        url = reverse("post-detail", args=[post.id])
+        response = cast(Response, self.client.delete(url))
         self.assertEqual(response.status_code, 204)
         self.assertEqual(Post.objects.count(), 0)
 
     def test_author_can_edit_own_post(self):
         post = Post.objects.create(title="Original", body="Body", author=self.user1)
         self.client.force_authenticate(user=self.user1)
+        url = reverse("post-detail", args=[post.id])
         response = cast(
             Response,
-            self.client.patch(
-                f"/forum/posts/{post.id}/", {"title": "Updated Title"}, format="json"
-            ),
+            self.client.patch(url, {"title": "Updated Title"}, format="json"),
         )
         self.assertEqual(response.status_code, 200)
         post.refresh_from_db()
@@ -55,6 +57,7 @@ class PostTests(TestCase):
     def test_non_author_cannot_delete_post(self):
         post = Post.objects.create(title="Protected", body="Body", author=self.user1)
         self.client.force_authenticate(user=self.user2)
-        response = cast(Response, self.client.delete(f"/forum/posts/{post.id}/"))
+        url = reverse("post-detail", args=[post.id])
+        response = cast(Response, self.client.delete(url))
         self.assertEqual(response.status_code, 403)
         self.assertEqual(Post.objects.count(), 1)


### PR DESCRIPTION
Previous absolute path usage brakes the tests when root path changes. All absolute path usages were changed wit reverse calls.