### PR TITLE
Enable HTTPS and Update Docker Setup

### DIFF
--- a/backend/project/settings.py
+++ b/backend/project/settings.py
@@ -35,6 +35,11 @@ DEBUG = True
 # TODO: Temporarily allow all host for development
 ALLOWED_HOSTS = ["*"]
 
+CSRF_TRUSTED_ORIGINS = [
+    "https://nutrihub.fit",
+    "https://www.nutrihub.fit",
+]
+
 
 # Application definition
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,10 +42,13 @@ services:
     container_name: nginx-frontend
     ports:
       - "80:80"
+      - "443:443"
     depends_on:
       - backend
     volumes:
       - static_volume:/usr/share/nginx/html/static
+      - ./certs:/etc/nginx/certs:ro
+      - ./frontend/nginx.conf:/etc/nginx/conf.d/default.conf:ro
 
 volumes:
   mysql_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,16 +1,21 @@
 FROM node:20-slim AS build
 
 WORKDIR /app
-COPY package*.json ./
+COPY package.json ./
 ARG VITE_API_BASE_URL
 ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
 RUN npm install
 COPY . .
 RUN npm run build
 
-# Production stage
 FROM nginx:alpine
+
 COPY --from=build /app/dist /usr/share/nginx/html
+
 COPY ./nginx.conf /etc/nginx/conf.d/default.conf
-EXPOSE 80
+
+RUN mkdir -p /etc/nginx/certs
+
+EXPOSE 80 443
+
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,6 +1,15 @@
 server {
     listen 80;
-    server_name localhost;
+    server_name nutrihub.fit www.nutrihub.fit;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name nutrihub.fit www.nutrihub.fit;
+
+    ssl_certificate /etc/nginx/certs/selfsigned.crt;
+    ssl_certificate_key /etc/nginx/certs/selfsigned.key;
 
     location / {
         root /usr/share/nginx/html;
@@ -15,5 +24,4 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
-
 }


### PR DESCRIPTION
### Summary
- Added TLS support using self-signed certificates.  
- Updated Nginx config to redirect HTTP to HTTPS.  
- Modified Docker and compose setup to mount certs and expose port 443.  
- Set `CSRF_TRUSTED_ORIGINS` in Django to allow HTTPS requests.

### Changes
- Updated Nginx config to handle TLS  
- Mounted `certs/` directory in `docker-compose.yml`  
- Exposed port 443 in frontend Dockerfile  
- Minor cleanup in frontend Dockerfile and settings