### PR TITLE
Feat/sorting in food catalog

### DIFF
--- a/backend/foods/views.py
+++ b/backend/foods/views.py
@@ -66,6 +66,7 @@ class FoodCatalog(ListAPIView):
 
         valid_sort_fields = {
             "nutritionscore": "nutritionScore",
+            "carbohydratecontent": "carbohydrateContent",
             "proteincontent": "proteinContent",
             "fatcontent": "fatContent",
         }

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -273,7 +273,7 @@ async function fetchJson<T>(url: string, options?: RequestInit, useRealBackend: 
 // api endpoints
 export const apiClient = {
   // foods
-  getFoods: (params?: { page?: number, search?: string}) => {
+  getFoods: (params?: { page?: number, search?: string, sort_by?: string, order?: string }) => {
     let url = "/foods";
     const queryParams = new URLSearchParams();
     if (params && params.page) {
@@ -281,6 +281,12 @@ export const apiClient = {
     }
     if (params && params.search) {
       queryParams.append('search', params.search);
+    }
+    if (params && params.sort_by) {
+      queryParams.append('sort_by', params.sort_by);
+    }
+    if (params && params.order) {
+      queryParams.append('order', params.order);
     }
     const queryString = queryParams.toString();
     if (queryString) {


### PR DESCRIPTION

# **Add sorting options to food catalog (frontend & backend integration)**

## Description
This PR introduces sorting functionality to the food catalog, allowing users to sort foods by Nutrition Score, Carbohydrate Content, Protein Content, or Fat Content, both in ascending and descending order. The sorting can be toggled via the frontend UI, and the backend now accepts and processes sorting parameters.

### Key Changes

- **Backend (`views.py`):**
  - Updated the food catalog endpoint to accept `sort_by` and `order` query parameters.
  - Supports sorting by `nutritionScore`, `carbohydrateContent`, `proteinContent`, and `fatContent` in both ascending and descending order.

- **Frontend (`Foods.tsx` and `apiClient.ts`):**
  - Added a "Sort By" toggle button between the search and add food buttons.
  - Sorting options panel allows users to select a field and toggle between descending, ascending, and no sort.
  - The sort panel remains open until the "Sort By" button is pressed again.
  - The frontend sends the selected sorting parameters to the backend when fetching foods.
  - UI feedback for current sorting state.

- **API Client:**
  - `getFoods` now accepts `sort_by` and `order` parameters and passes them to the backend.

---

closes #287 