### PR TITLE
Enable Let's Encrypt TLS with Certbot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,8 @@ services:
       - backend
     volumes:
       - static_volume:/usr/share/nginx/html/static
-      - ./certs:/etc/nginx/certs:ro
+      - ./certbot/www:/var/www/certbot
+      - ./certbot/conf:/etc/letsencrypt
       - ./frontend/nginx.conf:/etc/nginx/conf.d/default.conf:ro
 
 volumes:

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,15 +1,23 @@
 server {
     listen 80;
     server_name nutrihub.fit www.nutrihub.fit;
-    return 301 https://$host$request_uri;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
 }
 
+# HTTPS
 server {
     listen 443 ssl;
     server_name nutrihub.fit www.nutrihub.fit;
 
-    ssl_certificate /etc/nginx/certs/selfsigned.crt;
-    ssl_certificate_key /etc/nginx/certs/selfsigned.key;
+    ssl_certificate /etc/letsencrypt/live/nutrihub.fit/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/nutrihub.fit/privkey.pem;
 
     location / {
         root /usr/share/nginx/html;


### PR DESCRIPTION
### Changes
- Replaced self-signed certs with Let's Encrypt certs in `nginx.conf`
- Added ACME challenge route for Certbot
- Updated `docker-compose.yml` to mount:
  - `./certbot/www` for challenge path
  - `./certbot/conf` for cert storage

### Result
- HTTPS now uses real certs from Let's Encrypt
- Certbot can renew using webroot challenge