### PR TITLE
feat: added wikidata entity api endpoint

### DIFF
--- a/backend/352.postman_collection.json
+++ b/backend/352.postman_collection.json
@@ -871,6 +871,28 @@
 				"description": "**Submit a new food proposal**\n\nExample request body:\n```json\n{\n  \"name\": \"Greek Salad\",\n  \"category\": \"Salad\",\n  \"servingSize\": 150,\n  \"caloriesPerServing\": 120,\n  \"proteinContent\": 4.5,\n  \"fatContent\": 8.0,\n  \"carbohydrateContent\": 10.0,\n  \"dietaryOptions\": [\"Vegetarian\", \"Low-Carb\"],\n  \"nutritionScore\": 75.2,\n  \"imageUrl\": \"https://example.com/salad.jpg\",\n  \"allergens\": []\n}\n```"
 			},
 			"response": []
+		},
+		{
+			"name": "get_wikidata_entity",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://nutrihub.fit/api/food/Q193",
+					"protocol": "https",
+					"host": [
+						"nutrihub",
+						"fit"
+					],
+					"path": [
+						"api",
+						"food",
+						"Q193"
+					]
+				},
+				"description": "**Get detailed information for a specific food entity from Wikidata**\n\nThis endpoint retrieves detailed information about a food entity from Wikidata using its entity ID.\n\nPath parameter:\n- `entity_id`: The Wikidata entity ID (e.g., Q193 for 'beer')\n\nResponse includes:\n- Basic entity information (ID, label, description)\n- Wikipedia link if available\n- Food-related properties such as:\n  - subclass_of\n  - instance_of\n  - made_from_material\n  - has_parts\n  - has_effect\n  - has_nutritional_value\n\nExample response for beer (Q193):\n```json\n{\n  \"id\": \"Q193\",\n  \"label\": \"beer\",\n  \"description\": \"alcoholic drink fermented from starch material\",\n  \"wikipedia_link\": \"https://en.wikipedia.org/wiki/Beer\",\n  \"properties\": {\n    \"instance_of\": [\"Q2095\"],\n    \"made_from_material\": [\"Q5371\", \"Q7772\"],\n    \"has_effect\": [\"Q47495\"]\n  }\n}\n```"
+			},
+			"response": []
 		}
 	]
 }

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,6 +1,9 @@
 from django.urls import path
-from .views import TimeView
+from .views import TimeView, WikidataEntityView
 
 urlpatterns = [
     path("time", TimeView.as_view(), name="get-time"),
+    path(
+        "food/<str:entity_id>", WikidataEntityView.as_view(), name="get-wikidata-entity"
+    ),
 ]

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 from rest_framework.request import Request
 from rest_framework import status
 from datetime import datetime
+import requests
 
 
 class TimeView(APIView):
@@ -31,3 +32,106 @@ class TimeView(APIView):
                 {"error": "name is required"}, status=status.HTTP_400_BAD_REQUEST
             )
         return Response({"time": datetime.now().isoformat(), "name": name})
+
+
+class WikidataEntityView(APIView):
+    permission_classes = []
+
+    def get(self, request: Request, entity_id=None) -> Response:
+        """
+        GET /food/{entity_id}
+        Get detailed information about a specific food entity
+        """
+        if not entity_id:
+            return Response(
+                {"error": "Entity ID is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        try:
+            entity_data = self.get_wikidata_entity(entity_id)
+            if not entity_data:
+                return Response(
+                    {"error": f"Entity {entity_id} not found"},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+
+            return Response(entity_data)
+        except Exception as e:
+            return Response(
+                {"error": f"Failed to retrieve entity: {str(e)}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+    def get_wikidata_entity(self, entity_id):
+        """
+        Uses the wbgetentities API to get detailed information about an entity
+        """
+        api_url = "https://www.wikidata.org/w/api.php"
+
+        # Parameters for wbgetentities
+        params = {
+            "action": "wbgetentities",
+            "format": "json",
+            "ids": entity_id,
+            "languages": "en",
+            "props": "labels|descriptions|claims|sitelinks",
+        }
+
+        response = requests.get(
+            api_url, params=params, headers={"User-Agent": "WikidataFoodApp/1.0"}
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        if "entities" not in data or entity_id not in data["entities"]:
+            return None
+
+        entity = data["entities"][entity_id]
+
+        # Extract base entity information
+        result = {
+            "id": entity_id,
+            "label": entity.get("labels", {}).get("en", {}).get("value", "Unknown"),
+            "description": entity.get("descriptions", {})
+            .get("en", {})
+            .get("value", ""),
+            "wikipedia_link": self.extract_wikipedia_link(entity),
+        }
+
+        # Extract basic food properties if available
+        food_properties = {
+            "P279": "subclass_of",  # subclass of
+            "P31": "instance_of",  # instance of
+            "P186": "made_from_material",  # made from material
+            "P527": "has_parts",  # has parts
+            "P1542": "has_effect",  # has effect
+            "P2670": "has_nutritional_value",  # has nutritional value
+        }
+
+        properties = {}
+        for prop_id, prop_name in food_properties.items():
+            if prop_id in entity.get("claims", {}):
+                values = []
+                for claim in entity["claims"][prop_id]:
+                    if "mainsnak" in claim and "datavalue" in claim["mainsnak"]:
+                        if (
+                            claim["mainsnak"]["datavalue"]["type"]
+                            == "wikibase-entityid"
+                        ):
+                            values.append(claim["mainsnak"]["datavalue"]["value"]["id"])
+                if values:
+                    properties[prop_name] = values
+
+        if properties:
+            result["properties"] = properties
+
+        return result
+
+    def extract_wikipedia_link(self, entity):
+        """Extract English Wikipedia link if available"""
+        sitelinks = entity.get("sitelinks", {})
+        if "enwiki" in sitelinks:
+            title = sitelinks["enwiki"].get("title", "")
+            if title:
+                return f"https://en.wikipedia.org/wiki/{title.replace(' ', '_')}"
+        return None

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -56,7 +56,7 @@ class WikidataEntityView(APIView):
                 )
 
             return Response(entity_data)
-        except Exception as e:
+        except requests.exceptions.RequestException as e:
             return Response(
                 {"error": f"Failed to retrieve entity: {str(e)}"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
# add wikidata entity external api

## changes
- added wikidata api endpoint to fetch food entity data
- added route in urls.py 
- added postman request for testing

## testing
- use postman request "get_wikidata_entity"
- example: https://nutrihub.fit/api/food/Q193 (beer)
- returns detailed food information from wikidata including properties and wikipedia link