### PR TITLE
fix: use blue color for selected options in light mode

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -71,6 +71,15 @@
   --forum-filter-container-border: #374151; /* gray-700 */
   --forum-filter-container-text: #e5e7eb; /* gray-200 */
 
+  /* Dietary options selector - dark mode */
+  --dietary-option-bg: #333333;
+  --dietary-option-text: #bbbbbb;
+  --dietary-option-border: #374151;
+  --dietary-option-hover-bg: #444444;
+  --dietary-option-selected-bg: #3b82f6; /* blue-500 */
+  --dietary-option-selected-text: white;
+  --dietary-option-selected-border: #3b82f6;
+
   /* gray scale */
   --color-gray-50: #f9fafb;
   --color-gray-100: #f3f4f6;
@@ -184,6 +193,15 @@
   --forum-filter-container-bg: #f9fafb; /* gray-50 */
   --forum-filter-container-border: #e5e7eb; /* gray-200 */
   --forum-filter-container-text: #111827; /* gray-900 */
+
+  /* Dietary options selector - light mode */
+  --dietary-option-bg: #f2f2f2; /* light gray */
+  --dietary-option-text: #374151; /* gray-700 */
+  --dietary-option-border: #d1d5db; /* gray-300 */
+  --dietary-option-hover-bg: #e5e5e5; /* hover gray */
+  --dietary-option-selected-bg: #2563eb; /* blue-600 - darker blue for better visibility */
+  --dietary-option-selected-text: white;
+  --dietary-option-selected-border: #2563eb;
 
   /* shadows for light mode */
   --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);

--- a/frontend/src/pages/foods/ProposeNewFood.tsx
+++ b/frontend/src/pages/foods/ProposeNewFood.tsx
@@ -386,11 +386,28 @@ const ProposeNewFood: React.FC = () => {
                       {dietaryOptions.map((option) => (
                         <div 
                           key={option}
-                          className={`px-3 py-2 rounded-full cursor-pointer border transition-colors ${
-                            selectedDietaryOptions.includes(option)
-                              ? 'bg-primary text-white border-primary'
-                              : 'bg-[var(--forum-default-bg)] text-[var(--forum-default-text)] border-[var(--forum-search-border)] hover:bg-[var(--forum-default-hover-bg)]'
-                          }`}
+                          className="px-3 py-2 rounded-full cursor-pointer border transition-colors"
+                          style={{
+                            backgroundColor: selectedDietaryOptions.includes(option)
+                              ? 'var(--dietary-option-selected-bg)'
+                              : 'var(--dietary-option-bg)',
+                            color: selectedDietaryOptions.includes(option)
+                              ? 'var(--dietary-option-selected-text)'
+                              : 'var(--dietary-option-text)',
+                            borderColor: selectedDietaryOptions.includes(option)
+                              ? 'var(--dietary-option-selected-border)'
+                              : 'var(--dietary-option-border)'
+                          }}
+                          onMouseEnter={(e) => {
+                            if (!selectedDietaryOptions.includes(option)) {
+                              e.currentTarget.style.backgroundColor = 'var(--dietary-option-hover-bg)';
+                            }
+                          }}
+                          onMouseLeave={(e) => {
+                            if (!selectedDietaryOptions.includes(option)) {
+                              e.currentTarget.style.backgroundColor = 'var(--dietary-option-bg)';
+                            }
+                          }}
                           onClick={() => handleDietaryOptionsChange(option)}
                         >
                           {option}


### PR DESCRIPTION
fixed the light mode issue by adding blue color for selected options

<img width="657" height="161" alt="image" src="https://github.com/user-attachments/assets/bc638e5a-960d-482d-8c24-56597c9673a4" />

closes #452 