### PR TITLE
Added new flags to docker-compose to switch between prod/dev build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,9 +39,10 @@ services:
       context: ./frontend
       args:
         VITE_API_BASE_URL: /api
+        BUILD: ${BUILD:-DEV}
     container_name: nginx-frontend
     ports:
-      - "80:80"
+      - "${PORT:-8080}:80"
       - "443:443"
     depends_on:
       - backend
@@ -49,7 +50,6 @@ services:
       - static_volume:/usr/share/nginx/html/static
       - ./certbot/www:/var/www/certbot
       - ./certbot/conf:/etc/letsencrypt
-      - ./frontend/nginx.conf:/etc/nginx/conf.d/default.conf:ro
 
 volumes:
   mysql_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,11 +10,20 @@ RUN npm run build
 
 FROM nginx:alpine
 
+ARG BUILD=DEV
+
 COPY --from=build /app/dist /usr/share/nginx/html
 
-COPY ./nginx.conf /etc/nginx/conf.d/default.conf
-
 RUN mkdir -p /etc/nginx/certs
+
+COPY nginx-dev.conf /tmp/nginx-dev.conf
+COPY nginx.conf /tmp/nginx.conf
+
+RUN if [ "$BUILD" = "PROD" ]; then \
+        cp /tmp/nginx.conf /etc/nginx/conf.d/default.conf; \
+    else \
+        cp /tmp/nginx-dev.conf /etc/nginx/conf.d/default.conf; \
+    fi && rm /tmp/nginx*.conf
 
 EXPOSE 80 443
 

--- a/frontend/nginx-dev.conf
+++ b/frontend/nginx-dev.conf
@@ -1,0 +1,22 @@
+server {
+    listen 80;
+    server_name nutrihub.fit www.nutrihub.fit;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html;
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+        proxy_pass http://backend:9000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
- New flag is called BUILD and is read from environment
- PORT flag can be used to set the port the frontend is exposed (default port is 8080)
```sh
BUILD=PROD PORT=80 docker-compose up --build # production 
docker-compose up --build # development
```

Close #483