### PR TITLE
fix: make Join Forum button blue.

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -18,7 +18,7 @@ const Home = () => {
                     <Link to="/foods" className="nh-button nh-button-lg nh-button-primary flex items-center justify-center">
                         Explore Foods
                     </Link>
-                    <Link to="/forum" className="nh-button nh-button-lg nh-button-secondary flex items-center justify-center">
+                    <Link to="/forum" className="nh-button nh-button-lg nh-button-primary flex items-center justify-center">
                         Join Forum
                     </Link>
                     <Link to="/mealplanner" className="nh-button nh-button-lg nh-button-primary flex items-center justify-center">


### PR DESCRIPTION
As mentioned by Yusuf at [#488](https://github.com/bounswe/bounswe2025group9/issues/488), the coloring of the buttons seem inconsistent. This is why the color of the `Join Forum` button is made blue, matching with other two buttons.

Closes #488 