### PR TITLE
fix: improve dark mode text contrast in profile screens

### DIFF
--- a/mobile/nutrihub/src/screens/user/MyProfileScreen.tsx
+++ b/mobile/nutrihub/src/screens/user/MyProfileScreen.tsx
@@ -245,7 +245,7 @@ const MyProfileScreen: React.FC = () => {
                   <Text
                     style={[
                       textStyles.body,
-                      { color: viewMode === 'shared' ? theme.primary : theme.textSecondary }
+                      { color: viewMode === 'shared' ? theme.primary : theme.text }
                     ]}
                   >
                     Shared ({userPosts.length})
@@ -261,7 +261,7 @@ const MyProfileScreen: React.FC = () => {
                   <Text
                     style={[
                       textStyles.body,
-                      { color: viewMode === 'liked' ? theme.primary : theme.textSecondary }
+                      { color: viewMode === 'liked' ? theme.primary : theme.text }
                     ]}
                   >
                     Liked ({likedPosts.length})

--- a/mobile/nutrihub/src/screens/user/UserProfileScreen.tsx
+++ b/mobile/nutrihub/src/screens/user/UserProfileScreen.tsx
@@ -260,7 +260,7 @@ const UserProfileScreen: React.FC = () => {
                 style={[styles.tabButton, viewMode === 'shared' && { borderBottomColor: theme.primary, borderBottomWidth: 2 }]}
                 onPress={() => setViewMode('shared')}
               >
-                <Text style={[styles.tabText, viewMode === 'shared' && { color: theme.primary }]}>Posts</Text>
+                <Text style={[styles.tabText, { color: viewMode === 'shared' ? theme.primary : theme.text }]}>Posts</Text>
               </TouchableOpacity>
 
               {(() => {
@@ -272,7 +272,7 @@ const UserProfileScreen: React.FC = () => {
                   style={[styles.tabButton, viewMode === 'liked' && { borderBottomColor: theme.primary, borderBottomWidth: 2 }]}
                   onPress={() => setViewMode('liked')}
                 >
-                  <Text style={[styles.tabText, viewMode === 'liked' && { color: theme.primary }]}>Liked</Text>
+                  <Text style={[styles.tabText, { color: viewMode === 'liked' ? theme.primary : theme.text }]}>Liked</Text>
                 </TouchableOpacity>
               )}
             </View>
@@ -288,13 +288,13 @@ const UserProfileScreen: React.FC = () => {
                   style={[styles.chip, likedFilter === 'all' && { backgroundColor: `${theme.primary}20` }]}
                   onPress={() => setLikedFilter('all')}
                 >
-                  <Text style={[styles.chipText, likedFilter === 'all' && { color: theme.primary }]}>All</Text>
+                  <Text style={[styles.chipText, { color: likedFilter === 'all' ? theme.primary : theme.text }]}>All</Text>
                 </TouchableOpacity>
                 <TouchableOpacity
                   style={[styles.chip, likedFilter === 'recipes' && { backgroundColor: `${theme.primary}20` }]}
                   onPress={() => setLikedFilter('recipes')}
                 >
-                  <Text style={[styles.chipText, likedFilter === 'recipes' && { color: theme.primary }]}>Recipes</Text>
+                  <Text style={[styles.chipText, { color: likedFilter === 'recipes' ? theme.primary : theme.text }]}>Recipes</Text>
                 </TouchableOpacity>
               </View>
             )}


### PR DESCRIPTION
Fixes #494

## 🐛 Problem
Unselected text on profile screens was not visible in dark mode due to poor contrast. The text was using `theme.textSecondary` color (`#d1d5db`) which blended with the dark background, making it nearly invisible.

## 🎯 Solution
Changed unselected text color from `theme.textSecondary` to `theme.text` for better contrast in dark mode while maintaining the visual hierarchy.

## 📝 Changes Made

### Files Modified:
- `mobile/nutrihub/src/screens/user/MyProfileScreen.tsx`
- `mobile/nutrihub/src/screens/user/UserProfileScreen.tsx`

### Specific Changes:
1. **Tab Text Styling**: Updated unselected tab text color from `theme.textSecondary` to `theme.text`
2. **Filter Chip Text**: Applied consistent contrast improvements to filter chips
3. **Maintained Visual Hierarchy**: Selected text still uses `theme.primary` color for active state

## 🎨 Before vs After

### Before:
- Unselected text: `#d1d5db` (theme.textSecondary) - poor contrast
- Selected text: `#3B82F6` (theme.primary) - good contrast

### After:
- Unselected text: `#e5e7eb` (theme.text) - good contrast ✅
- Selected text: `#3B82F6` (theme.primary) - good contrast ✅
