### PR TITLE
Fix mobile profile photo upload functionality

### DIFF
--- a/mobile/nutrihub/app.json
+++ b/mobile/nutrihub/app.json
@@ -13,14 +13,23 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.y4z1c1.nutrihub"
+      "bundleIdentifier": "com.y4z1c1.nutrihub",
+      "infoPlist": {
+        "NSCameraUsageDescription": "This app needs access to camera to take profile photos.",
+        "NSPhotoLibraryUsageDescription": "This app needs access to photo library to select profile photos."
+      }
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#0d7c5f"
       },
-      "package": "com.y4z1c1.nutrihub"
+      "package": "com.y4z1c1.nutrihub",
+      "permissions": [
+        "android.permission.CAMERA",
+        "android.permission.READ_EXTERNAL_STORAGE",
+        "android.permission.WRITE_EXTERNAL_STORAGE"
+      ]
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/mobile/nutrihub/src/screens/user/MyProfileScreen.tsx
+++ b/mobile/nutrihub/src/screens/user/MyProfileScreen.tsx
@@ -6,6 +6,7 @@ import {
   FlatList,
   TouchableOpacity,
   ActivityIndicator,
+  Alert,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
@@ -198,13 +199,20 @@ const MyProfileScreen: React.FC = () => {
             return (
               <View style={[styles.profileSection, { backgroundColor: theme.surface }]}>
                 <ProfilePhotoPicker
-                  uri={userProfile.profilePhoto}
-                  onUploaded={async (remoteUrl: string) => {
+                  uri={userProfile.profile_image}
+                  onUploaded={async (localUri: string) => {
                     try {
+                      console.log('Starting upload process for:', localUri);
+                      const name = localUri.split('/').pop() || 'profile.jpg';
+                      console.log('Uploading with filename:', name);
+                      const res = await userService.uploadProfilePhoto(localUri, name);
+                      console.log('Upload response:', res);
                       // Refresh profile data to get updated photo
                       fetchUserData();
+                      console.log('Profile updated successfully');
                     } catch (error) {
-                      console.error('Error updating profile:', error);
+                      console.error('Upload failed:', error);
+                      Alert.alert('Upload Failed', `Failed to upload image: ${error.message || error}`);
                     }
                   }}
                   onRemoved={async () => {

--- a/mobile/nutrihub/src/services/api/client.ts
+++ b/mobile/nutrihub/src/services/api/client.ts
@@ -33,6 +33,12 @@ class ApiClient {
           config.headers = config.headers || {};
           config.headers.Authorization = `Bearer ${token}`;
         }
+        
+        // For FormData, remove the default Content-Type to let axios handle it
+        if (config.data instanceof FormData) {
+          delete config.headers['Content-Type'];
+        }
+        
         return config;
       },
       (error) => {
@@ -138,6 +144,11 @@ class ApiClient {
 
   async post<T>(url: string, data?: any, config?: AxiosRequestConfig): Promise<ApiResponse<T>> {
     try {
+      // For FormData, don't set Content-Type manually to let axios handle the boundary
+      if (data instanceof FormData && config?.headers?.['Content-Type']) {
+        delete config.headers['Content-Type'];
+      }
+      
       const response = await this.axiosInstance.post<T>(url, data, config);
       return {
         data: response.data,

--- a/mobile/nutrihub/src/services/api/user.service.ts
+++ b/mobile/nutrihub/src/services/api/user.service.ts
@@ -1,8 +1,10 @@
 import { apiClient } from './client';
 import { User } from '../../types/types';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { API_CONFIG } from '../../config';
 
 export interface UploadPhotoResponse {
-  profilePhoto: string; // URL returned by backend
+  profile_image: string; // URL returned by backend
 }
 
 export const userService = {
@@ -10,33 +12,76 @@ export const userService = {
     // Flexible path: if backend differs, swap here only
     const response = await apiClient.get<User>(`/users/${encodeURIComponent(username)}/profile/`);
     if (response.error) throw new Error(response.error);
+    
+    // Convert relative profile_image URL to full URL
+    if (response.data?.profile_image && !response.data.profile_image.startsWith('http')) {
+      const baseUrl = 'https://nutrihub.fit'; // Use the base URL without /api
+      response.data.profile_image = `${baseUrl}${response.data.profile_image}`;
+    }
+    
     return response.data!;
   },
 
   async getMyProfile(): Promise<User> {
     const response = await apiClient.get<User>('/users/profile/');
     if (response.error) throw new Error(response.error);
+    
+    // Convert relative profile_image URL to full URL
+    if (response.data?.profile_image && !response.data.profile_image.startsWith('http')) {
+      const baseUrl = 'https://nutrihub.fit'; // Use the base URL without /api
+      response.data.profile_image = `${baseUrl}${response.data.profile_image}`;
+    }
+    
     return response.data!;
   },
 
   async uploadProfilePhoto(fileUri: string, fileName: string): Promise<UploadPhotoResponse> {
+    // Get auth token
+    const token = await AsyncStorage.getItem('access_token');
+    if (!token) {
+      throw new Error('No authentication token found');
+    }
+
+    // Create FormData
     const formData = new FormData();
-    formData.append('photo', {
-      // @ts-ignore React Native FormData file
+    const file = {
       uri: fileUri,
       name: fileName,
       type: fileName.toLowerCase().endsWith('.png') ? 'image/png' : 'image/jpeg',
-    });
+    };
+    
+    formData.append('profile_image', file as any);
 
-    const response = await apiClient.post<UploadPhotoResponse>('/users/profile/photo/', formData, {
-      headers: { 'Content-Type': 'multipart/form-data' },
-    });
-    if (response.error) throw new Error(response.error);
-    return response.data!;
+    try {
+      const response = await fetch(`${API_CONFIG.BASE_URL}/users/image/`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+        },
+        body: formData,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Upload failed: ${response.status} - ${errorText}`);
+      }
+
+      const data = await response.json();
+      
+      // Convert relative URL to full URL
+      if (data.profile_image && !data.profile_image.startsWith('http')) {
+        const baseUrl = API_CONFIG.BASE_URL.replace('/api', '');
+        data.profile_image = `${baseUrl}${data.profile_image}`;
+      }
+      
+      return data as UploadPhotoResponse;
+    } catch (error) {
+      throw error;
+    }
   },
 
   async removeProfilePhoto(): Promise<void> {
-    const response = await apiClient.post('/users/profile/photo/remove/');
+    const response = await apiClient.delete('/users/image/');
     if (response.error) throw new Error(response.error);
   },
 };

--- a/mobile/nutrihub/src/types/types.ts
+++ b/mobile/nutrihub/src/types/types.ts
@@ -129,7 +129,7 @@ export interface User {
   allergens?: string[];
   createdAt?: Date;
   // Optional public profile fields
-  profilePhoto?: string; // URL
+  profile_image?: string; // URL - matches backend field name
   profession?: string;
   bio?: string;
   badges?: string[];


### PR DESCRIPTION
## 📝 Description  
Fixes #499 the **"Invalid image – Could not validate file size"** error that prevented users from uploading profile photos in the mobile app. The issue stemmed from multiple API and configuration-related problems, all of which have now been resolved.

---

## 🎯 Problem  
- Users were unable to upload profile photos on mobile  
- **Error shown:** `Invalid image – Could not validate file size`  
- Image picker opened, but the upload failed  
- A gray placeholder image was displayed instead of the uploaded image  

---

## 🔧 Root Causes Identified & Fixed  

### 1. API Endpoint Mismatch  
| Status | Endpoint |
|--------|---------|
| ❌ Before | `/users/profile/photo/` |
| ✅ After  | `/users/image/` |
