### PR TITLE
Show user profile picture in “Add a Comment” section 

### DIFF
--- a/frontend/src/pages/forum/PostDetail.tsx
+++ b/frontend/src/pages/forum/PostDetail.tsx
@@ -767,12 +767,14 @@ const PostDetail = () => {
                                 <form onSubmit={handleCommentSubmit}>
                                     <div className="flex items-start gap-3 mb-4">
                                         <div className="flex-shrink-0">
-                                            <div className="w-10 h-10 rounded-full bg-primary bg-opacity-10 flex items-center justify-center">
-                                                <User size={18} weight="fill" className="text-primary" />
-                                            </div>
+                                            <ProfileImage 
+                                                profileImage={user?.profile_image}
+                                                username={username}
+                                                size="md"
+                                            />
                                         </div>
                                         <div className="flex-grow">
-                                            <p className="font-semibold text-primary mb-2">You</p>
+                                            <p className="font-semibold text-primary mb-2">{username || 'You'}</p>
                                             <textarea 
                                                 className="w-full p-2 border rounded-md bg-[var(--forum-search-bg)] border-[var(--forum-search-border)] text-[var(--forum-search-text)] placeholder:text-[var(--forum-search-placeholder)] focus:ring-1 focus:ring-[var(--forum-search-focus-ring)] focus:border-[var(--forum-search-focus-border)] transition-all"
                                                 rows={3}


### PR DESCRIPTION
### Summary
- **Enhancement**: Display the signed-in user’s profile image and username in the add comment form on the post detail page.
- **Consistency**: Reuses `ProfileImage` for a consistent avatar experience across the app.

### Files Changed
- `frontend/src/pages/forum/PostDetail.tsx`
  - Replaced placeholder icon with:
    - `ProfileImage` using `user?.profile_image`
    - Username label using `username` (fallback to “You”)

### Testing
- Log in and open a forum post detail page.
- Verify the add comment area shows:
  - Your profile image (or default icon if none)
  - Your username above the textarea
- Submit a comment to confirm no regressions.

closes #516 
