### PR TITLE
Adjusting layout of other people's profile view.

### DIFF
--- a/mobile/nutrihub/src/screens/user/MyPostsScreen.tsx
+++ b/mobile/nutrihub/src/screens/user/MyPostsScreen.tsx
@@ -30,7 +30,7 @@ interface ProfileSection {
 
 const MyPostsScreen: React.FC = () => {
   const { theme, textStyles } = useTheme();
-  const navigation = useNavigation();
+  const navigation = useNavigation<any>();
 
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
@@ -57,10 +57,10 @@ const MyPostsScreen: React.FC = () => {
         bio: 'Passionate about healthy cooking and nutrition',
         profile_image: null,
         profession_tags: [
-          { id: 1, name: 'Dietitian', is_verified: true, created_at: new Date() },
-          { id: 2, name: 'Chef', is_verified: false, created_at: new Date() }
+          { id: 1, name: 'Dietitian', verified: true, certificate: null },
+          { id: 2, name: 'Chef', verified: false, certificate: null }
         ],
-        allergens: ['gluten', 'lactose'],
+        allergens: [],
         custom_allergens: ['sesame'],
         badges: ['Top Contributor', 'Recipe Master'],
         account_warnings: [

--- a/mobile/nutrihub/src/screens/user/MyProfileScreen.tsx
+++ b/mobile/nutrihub/src/screens/user/MyProfileScreen.tsx
@@ -46,6 +46,7 @@ const MyProfileScreen: React.FC = () => {
   const [viewMode, setViewMode] = useState<'shared' | 'liked'>('shared');
   const [likedFilter, setLikedFilter] = useState<'all' | 'recipes'>('all');
   const [loading, setLoading] = useState(true);
+  const [photoUpdating, setPhotoUpdating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // Fetch ALL posts and filter by username to avoid filter dependency
@@ -55,7 +56,7 @@ const MyProfileScreen: React.FC = () => {
     setLoading(true);
     try {
       // Fetch user profile
-      const profile = await userService.getMyProfile();
+      const profile = await userService.getMyProfile(true);
       setUserProfile(profile);
 
       // Fetch all posts and filter by current user
@@ -198,30 +199,49 @@ const MyProfileScreen: React.FC = () => {
           if (item.key === 'profile') {
             return (
               <View style={[styles.profileSection, { backgroundColor: theme.surface }]}>
-                <ProfilePhotoPicker
-                  uri={userProfile.profile_image}
-                  onUploaded={async (localUri: string) => {
+              <ProfilePhotoPicker
+                uri={userProfile.profile_image}
+                uploading={photoUpdating}
+                onUploaded={async (localUri: string) => {
+                  try {
+                    setPhotoUpdating(true);
+                    const name = localUri.split('/').pop() || 'profile.jpg';
+                    const res = await userService.uploadProfilePhoto(localUri, name);
+
+                    setUserProfile(prev => prev ? { ...prev, profile_image: res.profile_image } : prev);
+                    
                     try {
-                      console.log('Starting upload process for:', localUri);
-                      const name = localUri.split('/').pop() || 'profile.jpg';
-                      console.log('Uploading with filename:', name);
-                      const res = await userService.uploadProfilePhoto(localUri, name);
-                      console.log('Upload response:', res);
-                      // Refresh profile data to get updated photo
-                      fetchUserData();
-                      console.log('Profile updated successfully');
-                    } catch (error) {
-                      console.error('Upload failed:', error);
-                      Alert.alert('Upload Failed', `Failed to upload image: ${error.message || error}`);
+                      const refreshed = await userService.getMyProfile(true);
+                      setUserProfile(refreshed);
+                    } catch (refreshError) {
+                      console.warn('Failed to refresh profile after upload', refreshError);
+                    }
+                  } catch (error) {
+                    console.error('Upload failed:', error);
+                    const message = error instanceof Error ? error.message : String(error);
+                    Alert.alert('Upload Failed', `Failed to upload image: ${message}`);
+                  } finally {
+                      setPhotoUpdating(false);
                     }
                   }}
                   onRemoved={async () => {
                     try {
+                      setPhotoUpdating(true);
                       await userService.removeProfilePhoto();
-                      // Refresh profile data
-                      fetchUserData();
+                      setUserProfile(prev => prev ? { ...prev, profile_image: null } : prev);
+                      
+                      try {
+                        const refreshed = await userService.getMyProfile(true);
+                        setUserProfile(refreshed);
+                      } catch (refreshError) {
+                        console.warn('Failed to refresh profile after removal', refreshError);
+                      }
                     } catch (error) {
                       console.error('Error removing photo:', error);
+                      const message = error instanceof Error ? error.message : String(error);
+                      Alert.alert('Remove Failed', `Failed to remove image: ${message}`);
+                    } finally {
+                      setPhotoUpdating(false);
                     }
                   }}
                 />

--- a/mobile/nutrihub/src/screens/user/ProfessionTagsScreen.tsx
+++ b/mobile/nutrihub/src/screens/user/ProfessionTagsScreen.tsx
@@ -63,7 +63,7 @@ const ProfessionTagsScreen: React.FC = () => {
     try {
       console.log('Adding profession tag:', tagName);
       const newTags = await userService.setProfessionTags([
-        ...professionTags.map(tag => ({ name: tag.name, verified: tag.is_verified })),
+        ...professionTags.map(tag => ({ name: tag.name, verified: tag.verified })),
         { name: tagName, verified: false }
       ]);
       console.log('API returned tags:', newTags);
@@ -89,7 +89,7 @@ const ProfessionTagsScreen: React.FC = () => {
       console.log('Removing profession tag:', tagId);
       const updatedTags = professionTags.filter(tag => tag.id !== tagId);
       await userService.setProfessionTags(
-        updatedTags.map(tag => ({ name: tag.name, verified: tag.is_verified }))
+        updatedTags.map(tag => ({ name: tag.name, verified: tag.verified }))
       );
       setProfessionTags(updatedTags);
       
@@ -173,7 +173,7 @@ const ProfessionTagsScreen: React.FC = () => {
         <View style={styles.tagHeader}>
           <Text style={[textStyles.heading4, { color: theme.text }]}>{item.name}</Text>
           <View style={styles.tagStatus}>
-            {item.is_verified ? (
+            {item.verified ? (
               <View style={[styles.verifiedBadge, { backgroundColor: theme.success }]}>
                 <Icon name="check-circle" size={16} color="#fff" />
                 <Text style={[textStyles.small, { color: '#fff' }]}>Verified</Text>
@@ -187,7 +187,7 @@ const ProfessionTagsScreen: React.FC = () => {
           </View>
         </View>
         
-        {item.certificate_url && (
+        {item.certificate && (
           <View style={styles.certificateInfo}>
             <Icon name="certificate" size={16} color={theme.primary} />
               <Text style={[textStyles.caption, { color: theme.primary }]}>
@@ -205,19 +205,19 @@ const ProfessionTagsScreen: React.FC = () => {
             {uploading === item.id ? (
               <ActivityIndicator size="small" color="#fff" />
             ) : (
-              <Icon name={item.certificate_url ? "file-document-edit" : "upload"} size={16} color="#fff" />
+              <Icon name={item.certificate ? "file-document-edit" : "upload"} size={16} color="#fff" />
             )}
             <Text style={[textStyles.caption, { color: '#fff' }]}>
               {uploading === item.id 
                 ? 'Uploading...' 
-                : item.certificate_url 
+                : item.certificate 
                   ? 'Change Document' 
                   : 'Upload Document'
               }
             </Text>
           </TouchableOpacity>
           
-          {item.certificate_url && (
+          {item.certificate && (
             <TouchableOpacity
               style={[styles.actionButton, styles.removeButton, { borderColor: theme.warning }]}
               onPress={() => removeCertificate(item.id)}

--- a/mobile/nutrihub/src/screens/user/ProfileSettingsScreen.tsx
+++ b/mobile/nutrihub/src/screens/user/ProfileSettingsScreen.tsx
@@ -192,7 +192,7 @@ const ProfileSettingsScreen: React.FC = () => {
                   <Text style={[textStyles.caption, { color: '#fff' }]}>
                     {tag.name}
                   </Text>
-                  {tag.is_verified ? (
+                  {tag.verified ? (
                     <View style={[styles.verifiedBadge, { backgroundColor: theme.success }]}>
                       <Icon name="check-circle" size={12} color="#fff" style={styles.tagIcon} />
                     </View>

--- a/mobile/nutrihub/src/screens/user/UserProfileScreen.tsx
+++ b/mobile/nutrihub/src/screens/user/UserProfileScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   View,
   Text,
@@ -32,7 +32,7 @@ const UserProfileScreen: React.FC = () => {
   const navigation = useNavigation<UserProfileNavigationProp>();
   const route = useRoute<UserProfileRouteProp>();
 
-  const { username } = route.params;
+  const { username, userId } = route.params;
   const { user: currentUser } = useAuth();
 
   const getCurrentUserDisplayName = (): string => {
@@ -55,6 +55,39 @@ const UserProfileScreen: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  const privacySettings = userProfile?.privacy_settings;
+  const isFieldVisible = (flag?: boolean) => flag !== false;
+
+  const canShowProfessionTags = isOwner || isFieldVisible(privacySettings?.show_profession_tags);
+  const canShowBadges = isOwner || isFieldVisible(privacySettings?.show_badges);
+  const canShowPosts = isOwner || isFieldVisible(privacySettings?.show_posts);
+  const canShowRecipes = isOwner || isFieldVisible(privacySettings?.show_recipes);
+  const canShowLocation = isOwner || isFieldVisible(privacySettings?.show_location);
+  const canShowLiked = isOwner;
+
+  const professionTags = useMemo<ProfessionTag[]>(() => {
+    if (!userProfile) return [];
+    if (userProfile.tags && userProfile.tags.length > 0) {
+      return userProfile.tags;
+    }
+    if (userProfile.profession_tags && userProfile.profession_tags.length > 0) {
+      return userProfile.profession_tags;
+    }
+    return [];
+  }, [userProfile]);
+
+  const listData = useMemo<ForumTopic[]>(() => {
+    if (viewMode === 'liked') {
+      if (!canShowLiked) return [];
+      const likedRecipeOnly = likedPosts.filter(post =>
+        (post.tags || []).some(tag => tag?.toLowerCase().includes('recipe'))
+      );
+      return likedFilter === 'recipes' ? likedRecipeOnly : likedPosts;
+    }
+
+    return canShowPosts ? userPosts : [];
+  }, [viewMode, canShowLiked, likedFilter, likedPosts, canShowPosts, userPosts]);
+
   // Fetch ALL posts and filter by username to avoid filter dependency
   const fetchUserData = useCallback(async () => {
     setLoading(true);
@@ -64,7 +97,7 @@ const UserProfileScreen: React.FC = () => {
       // Attempt to fetch profile using the new method
       let fetchedProfile: User | null = null;
       try {
-        fetchedProfile = await userService.getOtherUserProfile(username);
+        fetchedProfile = await userService.getOtherUserProfile(username, userId);
         setUserProfile(fetchedProfile);
       } catch (e) {
         console.error('Error fetching user profile:', e);
@@ -133,6 +166,17 @@ const UserProfileScreen: React.FC = () => {
     }, [])
   );
 
+  useEffect(() => {
+    if (viewMode === 'liked' && !canShowLiked) {
+      setViewMode('shared');
+      return;
+    }
+
+    if (viewMode === 'shared' && !canShowPosts && canShowLiked) {
+      setViewMode('liked');
+    }
+  }, [viewMode, canShowLiked, canShowPosts]);
+
   const handleBack = () => {
     navigation.goBack();
   };
@@ -149,11 +193,30 @@ const UserProfileScreen: React.FC = () => {
     });
   };
 
-  const handleViewDocument = (tag: any) => {
-    if (tag.certificate_url) {
+  const handleViewDocument = (tag: ProfessionTag) => {
+    if (tag.certificate) {
       // TODO: Open document in a modal or external viewer
       Alert.alert('Document', `View document for ${tag.name}`);
     }
+  };
+
+  const renderEmptyComponent = () => {
+    let message = '';
+    let iconName: React.ComponentProps<typeof Icon>['name'] = 'post-outline';
+
+    if (viewMode === 'liked') {
+      message = 'No liked posts yet.';
+      iconName = 'heart-outline';
+    } else {
+      message = canShowPosts ? 'No posts from this user yet.' : 'This user keeps their posts private.';
+    }
+
+    return (
+      <View style={styles.emptyContainer}>
+        <Icon name={iconName} size={48} color={theme.textSecondary} />
+        <Text style={[styles.emptyText, textStyles.body]}>{message}</Text>
+      </View>
+    );
   };
 
   if (loading) {
@@ -215,176 +278,252 @@ const UserProfileScreen: React.FC = () => {
       </View>
 
       <FlatList
-        data={
-          viewMode === 'shared'
-            ? userPosts
-            : likedFilter === 'recipes'
-              ? likedPosts.filter(p => (p.tags || []).some(t => t.toLowerCase().includes('recipe')))
-              : likedPosts
-        }
+        data={listData}
         keyExtractor={(item) => `${viewMode}-${item.id}`}
         contentContainerStyle={styles.listContent}
         ListHeaderComponent={
-          <View>
-            <View style={styles.profileHeader}>
+          <View style={styles.headerContent}>
+            <View style={[styles.profileCard, { backgroundColor: theme.surface, borderColor: theme.border }]}>
               <ProfilePhotoPicker
                 uri={userProfile?.profile_image || null}
-                editable={Boolean(currentUser && (currentUser.username === username || username === getCurrentUserDisplayName() || (userProfile && currentUser.id === userProfile.id)))}
+                editable={isOwner}
                 onUploaded={async (localUri) => {
                   try {
                     const name = localUri.split('/').pop() || 'profile.jpg';
                     const res = await userService.uploadProfilePhoto(localUri, name);
-                    
-                    // Update local state immediately
+
                     setUserProfile(prev => prev ? { ...prev, profile_image: res.profile_image } : prev);
-                    
-                    // Also refresh profile data from server to ensure consistency
+
                     try {
-                      const refreshedProfile = await userService.getUserByUsername(username);
+                      const refreshedProfile = await userService.getOtherUserProfile(
+                        username,
+                        userProfile?.id ?? userId
+                      );
                       setUserProfile(refreshedProfile);
                     } catch (refreshError) {
-                      // Profile refresh failed, but local update should be sufficient
+                      // Silent refresh failure
                     }
-                  } catch (e) {
-                    Alert.alert('Upload Failed', `Failed to upload image: ${e.message || e}`);
+                  } catch (error) {
+                    const message = error instanceof Error ? error.message : String(error);
+                    Alert.alert('Upload Failed', `Failed to upload image: ${message}`);
                   }
                 }}
                 onRemoved={async () => {
                   try {
                     await userService.removeProfilePhoto();
-                    setUserProfile(prev => prev ? { ...prev, profile_image: undefined } : prev);
+                    setUserProfile(prev => prev ? { ...prev, profile_image: null } : prev);
                   } catch (e) {}
                 }}
-                removable={!!userProfile?.profile_image}
+                removable={isOwner && !!userProfile?.profile_image}
               />
-              <View style={styles.profileInfo}>
-                <Text style={[styles.displayName, textStyles.heading4]}>
-                  {(userProfile?.name || userProfile?.surname || (isOwner && (currentUser?.name || currentUser?.surname)))
-                    ? `${userProfile?.name || currentUser?.name || ''} ${userProfile?.surname || currentUser?.surname || ''}`.trim()
-                    : `@${username}`}
-                </Text>
-                {(userProfile?.name || userProfile?.surname || (isOwner && (currentUser?.name || currentUser?.surname))) && (
-                  <Text style={[styles.usernameText, textStyles.caption]}>@{username}</Text>
-                )}
-                {/* Profession Tags with Privacy Controls */}
-                {userProfile?.tags && userProfile.tags.length > 0 && (
-                  <View style={styles.professionTagsContainer}>
-                    <Text style={[textStyles.caption, { color: theme.textSecondary, marginBottom: SPACING.xs }]}>
-                      Profession
-                    </Text>
-                    <View style={styles.professionTagsRow}>
-                      {userProfile.tags.map((tag) => (
-                        <TouchableOpacity 
-                          key={tag.id} 
-                          style={[styles.professionTag, { backgroundColor: theme.primary }]}
-                          onPress={() => handleViewDocument(tag)}
-                        >
-                          <Text style={[textStyles.caption, { color: '#fff' }]}>
-                            {tag.name}
-                          </Text>
-                          {tag.is_verified ? (
-                            <View style={[styles.verifiedBadge, { backgroundColor: theme.success }]}>
-                              <Icon name="check-circle" size={12} color="#fff" style={styles.tagIcon} />
-                              <Text style={[textStyles.small, { color: '#fff' }]}>Verified</Text>
-                            </View>
-                          ) : (
-                            <View style={[styles.unverifiedBadge, { backgroundColor: theme.warning }]}>
-                              <Icon name="clock-outline" size={12} color="#fff" style={styles.tagIcon} />
-                              <Text style={[textStyles.small, { color: '#fff' }]}>Unverified</Text>
-                            </View>
-                          )}
-                          {tag.certificate_url && (
-                            <Icon name="file-document" size={12} color="#fff" style={styles.tagIcon} />
-                          )}
-                        </TouchableOpacity>
-                      ))}
-                    </View>
-                  </View>
-                )}
-                {userProfile?.bio && (
-                  <Text style={[styles.bioText, textStyles.body]}>{userProfile.bio}</Text>
-                )}
-                {/* Badges with Privacy Controls */}
-                {userProfile?.privacy_settings?.show_badges && userProfile?.badges && userProfile.badges.length > 0 && (
-                  <View style={styles.badgesContainer}>
-                    <Text style={[textStyles.caption, { color: theme.textSecondary, marginBottom: SPACING.xs }]}>
-                      Badges
-                    </Text>
-                    <View style={styles.badgesRow}>
-                      {userProfile.badges.map((badge, index) => (
-                        <View key={index} style={[styles.badge, { backgroundColor: theme.warning }]}>
-                          <Icon name="medal" size={12} color="#fff" style={styles.badgeIcon} />
-                          <Text style={[styles.badgeText, { color: '#fff' }]}>{badge}</Text>
-                        </View>
-                      ))}
-                    </View>
-                  </View>
-                )}
+              <Text style={[styles.profileName, textStyles.heading3, { color: theme.text }]}>
+                {(userProfile?.name || userProfile?.surname || (isOwner && (currentUser?.name || currentUser?.surname)))
+                  ? `${userProfile?.name || currentUser?.name || ''} ${userProfile?.surname || currentUser?.surname || ''}`.trim()
+                  : `@${username}`}
+              </Text>
+              {(userProfile?.name || userProfile?.surname || (isOwner && (currentUser?.name || currentUser?.surname))) && (
+                <Text style={[styles.profileUsername, textStyles.caption, { color: theme.textSecondary }]}>@{username}</Text>
+              )}
+              {userProfile?.bio && (
+                <Text style={[styles.profileBio, textStyles.body, { color: theme.text }]}>{userProfile.bio}</Text>
+              )}
+              <View style={styles.statsRow}>
+                <View style={styles.statItem}>
+                  <Text style={[styles.statValue, textStyles.heading4, { color: theme.primary }]}>
+                    {professionTags.length}
+                  </Text>
+                  <Text style={[styles.statLabel, textStyles.caption, { color: theme.textSecondary }]}>
+                    Profession Tags
+                  </Text>
+                </View>
+                <View style={styles.statItem}>
+                  <Text style={[styles.statValue, textStyles.heading4, { color: theme.success }]}>
+                    {userProfile?.badges?.length || 0}
+                  </Text>
+                  <Text style={[styles.statLabel, textStyles.caption, { color: theme.textSecondary }]}>
+                    Badges
+                  </Text>
+                </View>
+                <View style={styles.statItem}>
+                  <Text style={[styles.statValue, textStyles.heading4, { color: theme.warning }]}>
+                    {userProfile?.recipes?.length || 0}
+                  </Text>
+                  <Text style={[styles.statLabel, textStyles.caption, { color: theme.textSecondary }]}>
+                    Recipes
+                  </Text>
+                </View>
+              </View>
+            </View>
 
-                {/* Contact Information with Privacy Controls */}
+            {canShowProfessionTags && professionTags.length > 0 && (
+              <View style={[styles.sectionCard, { backgroundColor: theme.surface, borderColor: theme.border }]}>
+                <Text style={[styles.sectionTitle, textStyles.subtitle, { color: theme.text }]}>
+                  Profession Tags
+                </Text>
+                <View style={styles.professionTagsRow}>
+                  {professionTags.map((tag) => (
+                    <TouchableOpacity
+                      key={tag.id || tag.name}
+                      style={[styles.professionTag, { backgroundColor: `${theme.primary}20`, borderColor: theme.primary }]}
+                      onPress={() => handleViewDocument(tag)}
+                    >
+                      <Text style={[textStyles.caption, { color: theme.primary }]}>
+                        {tag.name}
+                      </Text>
+                      {tag.verified ? (
+                        <View style={[styles.verifiedBadge, { backgroundColor: theme.success }]}>
+                          <Icon name="check-circle" size={12} color="#fff" style={styles.tagIcon} />
+                          <Text style={[textStyles.small, { color: '#fff' }]}>Verified</Text>
+                        </View>
+                      ) : (
+                        <View style={[styles.unverifiedBadge, { backgroundColor: theme.warning }]}>
+                          <Icon name="clock-outline" size={12} color="#fff" style={styles.tagIcon} />
+                          <Text style={[textStyles.small, { color: '#fff' }]}>Unverified</Text>
+                        </View>
+                      )}
+                      {tag.certificate && (
+                        <Icon name="file-document" size={12} color={theme.primary} style={styles.tagIcon} />
+                      )}
+                    </TouchableOpacity>
+                  ))}
+                </View>
+              </View>
+            )}
+
+            {!canShowProfessionTags && !isOwner && professionTags.length > 0 && (
+              <View style={[styles.sectionCard, { backgroundColor: theme.surface, borderColor: theme.border }]}>
+                <Text style={[textStyles.caption, { color: theme.textSecondary }]}>
+                  This user keeps their profession tags private.
+                </Text>
+              </View>
+            )}
+
+            {canShowBadges && userProfile?.badges && userProfile.badges.length > 0 && (
+              <View style={[styles.sectionCard, { backgroundColor: theme.surface, borderColor: theme.border }]}>
+                <Text style={[styles.sectionTitle, textStyles.subtitle, { color: theme.text }]}>
+                  Badges
+                </Text>
+                <View style={styles.badgesRow}>
+                  {userProfile.badges.map((badge, index) => (
+                    <View key={index} style={[styles.badge, { backgroundColor: theme.warning }]}>
+                      <Icon name="medal" size={12} color="#fff" style={styles.badgeIcon} />
+                      <Text style={[styles.badgeText, { color: '#fff' }]}>{badge}</Text>
+                    </View>
+                  ))}
+                </View>
+              </View>
+            )}
+
+            {!canShowBadges && !isOwner && userProfile?.badges && userProfile.badges.length > 0 && (
+              <View style={[styles.sectionCard, { backgroundColor: theme.surface, borderColor: theme.border }]}>
+                <Text style={[textStyles.caption, { color: theme.textSecondary }]}>
+                  This user keeps their badges private.
+                </Text>
+              </View>
+            )}
+
+            {canShowRecipes && (
+              <View style={[styles.sectionCard, { backgroundColor: theme.surface, borderColor: theme.border }]}>
+                <Text style={[styles.sectionTitle, textStyles.subtitle, { color: theme.text }]}>
+                  Recipes
+                </Text>
+                {userProfile?.recipes && userProfile.recipes.length > 0 ? (
+                  userProfile.recipes.map((recipe) => (
+                    <View key={recipe.id} style={styles.recipeItem}>
+                      <Icon name="chef-hat" size={16} color={theme.primary} />
+                      <Text style={[textStyles.body, { marginLeft: SPACING.xs, color: theme.text }]}>
+                        {recipe.name}
+                      </Text>
+                    </View>
+                  ))
+                ) : (
+                  <Text style={[textStyles.caption, { color: theme.textSecondary }]}>
+                    No recipes shared yet.
+                  </Text>
+                )}
+              </View>
+            )}
+
+            {!canShowRecipes && !isOwner && userProfile?.recipes && userProfile.recipes.length > 0 && (
+              <View style={[styles.sectionCard, { backgroundColor: theme.surface, borderColor: theme.border }]}>
+                <Text style={[textStyles.caption, { color: theme.textSecondary }]}>
+                  This user keeps their recipes private.
+                </Text>
+              </View>
+            )}
+
+            {(canShowLocation && userProfile?.location) || userProfile?.website ? (
+              <View style={[styles.sectionCard, { backgroundColor: theme.surface, borderColor: theme.border }]}>
+                <Text style={[styles.sectionTitle, textStyles.subtitle, { color: theme.text }]}>
+                  Contact
+                </Text>
                 <View style={styles.contactInfo}>
-                  {userProfile?.privacy_settings?.show_location && userProfile?.location && (
+                  {canShowLocation && userProfile?.location && (
                     <View style={styles.contactItem}>
-                      <Icon name="map-marker" size={14} color={theme.textSecondary} />
-                      <Text style={[textStyles.caption, { color: theme.textSecondary }]}>
+                      <Icon name="map-marker" size={16} color={theme.textSecondary} />
+                      <Text style={[textStyles.body, { color: theme.textSecondary, marginLeft: SPACING.xs }]}>
                         {userProfile.location}
                       </Text>
                     </View>
                   )}
                   {userProfile?.website && (
                     <View style={styles.contactItem}>
-                      <Icon name="web" size={14} color={theme.textSecondary} />
-                      <Text style={[textStyles.caption, { color: theme.primary }]}>
+                      <Icon name="web" size={16} color={theme.textSecondary} />
+                      <Text style={[textStyles.body, { color: theme.primary, marginLeft: SPACING.xs }]}>
                         {userProfile.website}
                       </Text>
                     </View>
                   )}
                 </View>
               </View>
-            </View>
+            ) : null}
 
-            {/* Tabs for Posts / Liked */}
-            <View style={styles.tabsContainer}>
-              <TouchableOpacity
-                style={[styles.tabButton, viewMode === 'shared' && { borderBottomColor: theme.primary, borderBottomWidth: 2 }]}
-                onPress={() => setViewMode('shared')}
-              >
-                <Text style={[styles.tabText, { color: viewMode === 'shared' ? theme.primary : theme.text }]}>Posts</Text>
-              </TouchableOpacity>
+            {(canShowPosts || canShowLiked) && (
+              <View style={[styles.tabsCard, { backgroundColor: theme.surface, borderColor: theme.border }]}>
+                <View style={styles.tabsContainer}>
+                  {canShowPosts && (
+                    <TouchableOpacity
+                      style={[styles.tabButton, viewMode === 'shared' && { borderBottomColor: theme.primary }]}
+                      onPress={() => setViewMode('shared')}
+                    >
+                      <Text style={[styles.tabText, { color: viewMode === 'shared' ? theme.primary : theme.text }]}>
+                        Posts
+                      </Text>
+                    </TouchableOpacity>
+                  )}
 
-              {(() => {
-                const displayName = getCurrentUserDisplayName();
-                const isOwner = !!currentUser && (currentUser.username === username || username === displayName || (userProfile && currentUser.id === userProfile.id));
-                return isOwner;
-              })() && (
-                <TouchableOpacity
-                  style={[styles.tabButton, viewMode === 'liked' && { borderBottomColor: theme.primary, borderBottomWidth: 2 }]}
-                  onPress={() => setViewMode('liked')}
-                >
-                  <Text style={[styles.tabText, { color: viewMode === 'liked' ? theme.primary : theme.text }]}>Liked</Text>
-                </TouchableOpacity>
-              )}
-            </View>
+                  {canShowLiked && (
+                    <TouchableOpacity
+                      style={[styles.tabButton, viewMode === 'liked' && { borderBottomColor: theme.primary }]}
+                      onPress={() => setViewMode('liked')}
+                    >
+                      <Text style={[styles.tabText, { color: viewMode === 'liked' ? theme.primary : theme.text }]}>
+                        Liked
+                      </Text>
+                    </TouchableOpacity>
+                  )}
+                </View>
 
-            {/* Sub-filters when on Liked tab: All / Recipes */}
-            {viewMode === 'liked' && (() => {
-              const displayName = getCurrentUserDisplayName();
-              const isOwner = !!currentUser && (currentUser.username === username || username === displayName || (userProfile && currentUser.id === userProfile.id));
-              return isOwner;
-            })() && (
-              <View style={styles.subFiltersContainer}>
-                <TouchableOpacity
-                  style={[styles.chip, likedFilter === 'all' && { backgroundColor: `${theme.primary}20` }]}
-                  onPress={() => setLikedFilter('all')}
-                >
-                  <Text style={[styles.chipText, { color: likedFilter === 'all' ? theme.primary : theme.text }]}>All</Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={[styles.chip, likedFilter === 'recipes' && { backgroundColor: `${theme.primary}20` }]}
-                  onPress={() => setLikedFilter('recipes')}
-                >
-                  <Text style={[styles.chipText, { color: likedFilter === 'recipes' ? theme.primary : theme.text }]}>Recipes</Text>
-                </TouchableOpacity>
+                {viewMode === 'liked' && canShowLiked && (
+                  <View style={styles.subFiltersContainer}>
+                    <TouchableOpacity
+                      style={[styles.chip, likedFilter === 'all' && { backgroundColor: `${theme.primary}20` }]}
+                      onPress={() => setLikedFilter('all')}
+                    >
+                      <Text style={[styles.chipText, { color: likedFilter === 'all' ? theme.primary : theme.text }]}>
+                        All
+                      </Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      style={[styles.chip, likedFilter === 'recipes' && { backgroundColor: `${theme.primary}20` }]}
+                      onPress={() => setLikedFilter('recipes')}
+                    >
+                      <Text style={[styles.chipText, { color: likedFilter === 'recipes' ? theme.primary : theme.text }]}>
+                        Recipes
+                      </Text>
+                    </TouchableOpacity>
+                  </View>
+                )}
               </View>
             )}
           </View>
@@ -398,14 +537,7 @@ const UserProfileScreen: React.FC = () => {
             onAuthorPress={() => navigation.navigate('UserProfile', { username: item.author })}
           />
         )}
-        ListEmptyComponent={
-          <View style={styles.emptyContainer}>
-            <Icon name="post-outline" size={48} color={theme.textSecondary} />
-            <Text style={[styles.emptyText, textStyles.body]}>
-              {viewMode === 'shared' ? 'No posts from this user yet.' : 'No liked posts yet.'}
-            </Text>
-          </View>
-        }
+        ListEmptyComponent={renderEmptyComponent}
         showsVerticalScrollIndicator={false}
       />
     </SafeAreaView>
@@ -434,102 +566,157 @@ const styles = StyleSheet.create({
     width: 32,
   },
   listContent: {
-    padding: SPACING.md,
     paddingBottom: SPACING.xl,
   },
-  profileHeader: {
+  headerContent: {
+    paddingBottom: SPACING.lg,
+  },
+  profileCard: {
+    marginHorizontal: SPACING.md,
+    marginTop: SPACING.md,
+    padding: SPACING.lg,
+    borderRadius: BORDER_RADIUS.lg,
+    borderWidth: 1,
+    alignItems: 'center',
+  },
+  profileName: {
+    marginTop: SPACING.md,
+    textAlign: 'center',
+  },
+  profileUsername: {
+    marginTop: SPACING.xs,
+    textAlign: 'center',
+  },
+  profileBio: {
+    marginTop: SPACING.sm,
+    textAlign: 'center',
+  },
+  statsRow: {
     flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: SPACING.lg,
+    justifyContent: 'space-between',
+    width: '100%',
+    marginTop: SPACING.lg,
   },
-  avatar: {
-    width: 60,
-    height: 60,
-    borderRadius: BORDER_RADIUS.round,
+  statItem: {
     alignItems: 'center',
-    justifyContent: 'center',
-  },
-  profileInfo: {
-    marginLeft: SPACING.md,
     flex: 1,
   },
-  displayName: {
+  statValue: {
     marginBottom: SPACING.xs,
   },
-  username: {
-    marginBottom: SPACING.xs,
+  statLabel: {
+    textAlign: 'center',
   },
-  usernameText: {
+  sectionCard: {
+    marginHorizontal: SPACING.md,
+    marginTop: SPACING.md,
+    padding: SPACING.md,
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: 1,
+  },
+  sectionTitle: {
     marginBottom: SPACING.sm,
+  },
+  professionTagsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  professionTag: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.xs,
+    borderRadius: BORDER_RADIUS.sm,
+    borderWidth: 1,
+    marginRight: SPACING.sm,
+    marginBottom: SPACING.sm,
+  },
+  tagIcon: {
+    marginLeft: SPACING.xs,
+  },
+  verifiedBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginLeft: SPACING.xs,
+    paddingHorizontal: SPACING.xs,
+    paddingVertical: 2,
+    borderRadius: BORDER_RADIUS.xs,
+  },
+  unverifiedBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginLeft: SPACING.xs,
+    paddingHorizontal: SPACING.xs,
+    paddingVertical: 2,
+    borderRadius: BORDER_RADIUS.xs,
   },
   badgesRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',
   },
-  tabsContainer: {
+  badge: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginTop: SPACING.md,
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.xs,
+    borderRadius: BORDER_RADIUS.sm,
+    marginRight: SPACING.sm,
     marginBottom: SPACING.sm,
   },
+  badgeIcon: {
+    marginRight: SPACING.xs,
+  },
+  badgeText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  recipeItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: SPACING.xs,
+  },
+  contactInfo: {
+    marginTop: SPACING.xs,
+  },
+  contactItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: SPACING.xs,
+  },
+  tabsCard: {
+    marginHorizontal: SPACING.md,
+    marginTop: SPACING.md,
+    paddingHorizontal: SPACING.md,
+    paddingTop: SPACING.sm,
+    paddingBottom: SPACING.md,
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: 1,
+  },
+  tabsContainer: {
+    flexDirection: 'row',
+    borderBottomWidth: 1,
+  },
   tabButton: {
-    marginRight: SPACING.lg,
-    paddingBottom: SPACING.xs,
+    flex: 1,
+    paddingVertical: SPACING.sm,
+    alignItems: 'center',
+    borderBottomWidth: 2,
+    borderBottomColor: 'transparent',
   },
   tabText: {
     fontWeight: '600',
   },
   subFiltersContainer: {
     flexDirection: 'row',
-    alignItems: 'center',
-    marginTop: SPACING.xs,
-    marginBottom: SPACING.sm,
-    paddingHorizontal: SPACING.md,
+    marginTop: SPACING.sm,
   },
   chip: {
     paddingHorizontal: SPACING.sm,
-    paddingVertical: 6,
-    borderRadius: BORDER_RADIUS.xs,
+    paddingVertical: SPACING.xs,
+    borderRadius: BORDER_RADIUS.sm,
     marginRight: SPACING.sm,
   },
   chipText: {
-    fontWeight: '600',
-  },
-  professionBadge: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: SPACING.sm,
-    paddingVertical: SPACING.xs,
-    borderRadius: BORDER_RADIUS.sm,
-    marginBottom: SPACING.sm,
-  },
-  bioText: {
-    marginTop: SPACING.xs,
-    marginBottom: SPACING.sm,
-  },
-  badge: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: SPACING.xs,
-    paddingVertical: 2,
-    borderRadius: BORDER_RADIUS.xs,
-    marginRight: SPACING.xs,
-  },
-  badgeIcon: {
-    marginRight: 4,
-  },
-  badgeText: {
-    fontSize: 12,
-    fontWeight: '500',
-  },
-  sectionHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: SPACING.md,
-    marginBottom: SPACING.sm,
-  },
-  sectionTitle: {
-    marginLeft: SPACING.xs,
     fontWeight: '600',
   },
   emptyContainer: {
@@ -570,55 +757,6 @@ const styles = StyleSheet.create({
   reportButton: {
     padding: SPACING.sm,
   },
-  professionTagsContainer: {
-    marginBottom: SPACING.sm,
-  },
-  professionTagsRow: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: SPACING.xs,
-  },
-  professionTag: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: SPACING.sm,
-    paddingVertical: SPACING.xs,
-    borderRadius: BORDER_RADIUS.sm,
-    marginRight: SPACING.xs,
-    marginBottom: SPACING.xs,
-  },
-  tagIcon: {
-    marginLeft: SPACING.xs,
-  },
-  unverifiedBadge: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginLeft: SPACING.xs,
-    paddingHorizontal: SPACING.xs,
-    paddingVertical: 2,
-    borderRadius: BORDER_RADIUS.xs,
-  },
-  verifiedBadge: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginLeft: SPACING.xs,
-    paddingHorizontal: SPACING.xs,
-    paddingVertical: 2,
-    borderRadius: BORDER_RADIUS.xs,
-  },
-  badgesContainer: {
-    marginBottom: SPACING.sm,
-  },
-  contactInfo: {
-    marginTop: SPACING.sm,
-  },
-  contactItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: SPACING.xs,
-  },
 });
 
 export default UserProfileScreen;
-
-

--- a/mobile/nutrihub/src/services/api/user.service.ts
+++ b/mobile/nutrihub/src/services/api/user.service.ts
@@ -1,209 +1,241 @@
 import { apiClient } from './client';
-import { User, ProfessionTag } from '../../types/types';
+import { User, ProfessionTag, UserRecipeSummary } from '../../types/types';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { API_CONFIG } from '../../config';
 
 export interface UploadPhotoResponse {
-  profile_image: string; // URL returned by backend
+  profile_image: string;
 }
+
+const BASE_HOST = API_CONFIG.BASE_URL.replace('/api', '');
+
+const ensureAbsoluteUrl = (value?: string | null): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  if (/^https?:\/\//i.test(value)) {
+    return value;
+  }
+  const normalizedPath = value.startsWith('/') ? value : `/${value}`;
+  return `${BASE_HOST}${normalizedPath}`;
+};
+
+const normalizeProfessionTag = (tag: any): ProfessionTag => ({
+  id: Number(tag?.id),
+  name: String(tag?.name ?? ''),
+  verified: Boolean(tag?.verified),
+  certificate: ensureAbsoluteUrl(tag?.certificate) ?? null,
+});
+
+const normalizeRecipes = (recipes?: any[]): UserRecipeSummary[] => {
+  if (!Array.isArray(recipes)) {
+    return [];
+  }
+
+  return recipes
+    .filter(recipe => recipe && typeof recipe.id !== 'undefined')
+    .map((recipe) => ({
+      id: Number(recipe.id),
+      name: String(recipe.name ?? ''),
+      ingredients: recipe.ingredients,
+    }));
+};
+
+const normalizeUserProfile = (data: any): User => {
+  const normalizedTags = Array.isArray(data?.tags)
+    ? data.tags.map(normalizeProfessionTag)
+    : [];
+
+  const normalized: User = {
+    ...(data || {}),
+    id: Number(data?.id ?? 0),
+    username: String(data?.username ?? ''),
+    email: String(data?.email ?? ''),
+    name: data?.name ?? undefined,
+    surname: data?.surname ?? undefined,
+    address: data?.address ?? undefined,
+    profile_image: ensureAbsoluteUrl(data?.profile_image),
+    tags: normalizedTags,
+    profession_tags: normalizedTags,
+    recipes: normalizeRecipes(data?.recipes),
+    allergens: data?.allergens,
+  };
+
+  return normalized;
+};
+
+const listUsers = async (): Promise<User[]> => {
+  const response = await apiClient.get<any[]>('/users/');
+  if (response.error) {
+    throw new Error(response.error);
+  }
+
+  const users = Array.isArray(response.data) ? response.data : [];
+  return users.map(normalizeUserProfile);
+};
+
+const findUser = (
+  users: User[],
+  { username, userId }: { username?: string; userId?: number }
+): User | undefined => {
+  if (typeof userId === 'number') {
+    const matchById = users.find((user) => user.id === userId);
+    if (matchById) {
+      return matchById;
+    }
+  }
+
+  if (username) {
+    const lowered = username.toLowerCase();
+    return users.find((user) => user.username.toLowerCase() === lowered);
+  }
+
+  return undefined;
+};
+
+const normalizeUploadResponse = (data: any): UploadPhotoResponse => ({
+  profile_image: ensureAbsoluteUrl(data?.profile_image) ?? '',
+});
+
+const normalizeTagResponse = (tag: any): ProfessionTag => normalizeProfessionTag(tag);
 
 export const userService = {
   async getUserByUsername(username: string): Promise<User> {
-    // Flexible path: if backend differs, swap here only
-    const response = await apiClient.get<User>(`/users/${encodeURIComponent(username)}/profile/`);
-    if (response.error) throw new Error(response.error);
-    
-    // Convert relative profile_image URL to full URL
-    if (response.data?.profile_image && !response.data.profile_image.startsWith('http')) {
-      const baseUrl = 'https://nutrihub.fit'; // Use the base URL without /api
-      response.data.profile_image = `${baseUrl}${response.data.profile_image}`;
-    }
-    
-    return response.data!;
+    return this.getOtherUserProfile(username);
   },
 
-  async getMyProfile(): Promise<User> {
-    const response = await apiClient.get<User>('/users/profile/');
-    if (response.error) throw new Error(response.error);
-    
-    // Convert relative profile_image URL to full URL
-    if (response.data?.profile_image && !response.data.profile_image.startsWith('http')) {
-      const baseUrl = 'https://nutrihub.fit'; // Use the base URL without /api
-      response.data.profile_image = `${baseUrl}${response.data.profile_image}`;
+  async getMyProfile(forceRefresh: boolean = false): Promise<User> {
+    const url = forceRefresh ? `/users/profile/?_=${Date.now()}` : '/users/profile/';
+    const response = await apiClient.get<any>(url);
+    if (response.error) {
+      throw new Error(response.error);
     }
-    
-    return response.data!;
+    return normalizeUserProfile(response.data);
   },
 
   async uploadProfilePhoto(fileUri: string, fileName: string): Promise<UploadPhotoResponse> {
-    // Get auth token
     const token = await AsyncStorage.getItem('access_token');
     if (!token) {
       throw new Error('No authentication token found');
     }
 
-    // Create FormData
     const formData = new FormData();
     const file = {
       uri: fileUri,
       name: fileName,
       type: fileName.toLowerCase().endsWith('.png') ? 'image/png' : 'image/jpeg',
     };
-    
+
     formData.append('profile_image', file as any);
 
-    try {
-      const response = await fetch(`${API_CONFIG.BASE_URL}/users/image/`, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
-        body: formData,
-      });
+    const response = await fetch(`${API_CONFIG.BASE_URL}/users/image/`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      body: formData,
+    });
 
-      if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(`Upload failed: ${response.status} - ${errorText}`);
-      }
-
-      const data = await response.json();
-      
-      // Convert relative URL to full URL
-      if (data.profile_image && !data.profile_image.startsWith('http')) {
-        const baseUrl = API_CONFIG.BASE_URL.replace('/api', '');
-        data.profile_image = `${baseUrl}${data.profile_image}`;
-      }
-      
-      return data as UploadPhotoResponse;
-    } catch (error) {
-      throw error;
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Upload failed: ${response.status} - ${errorText}`);
     }
+
+    const data = await response.json();
+    return normalizeUploadResponse(data);
   },
 
   async removeProfilePhoto(): Promise<void> {
     const response = await apiClient.delete('/users/image/');
-    if (response.error) throw new Error(response.error);
-  },
-
-  // Profession Tags
-  async getProfessionTags(): Promise<ProfessionTag[]> {
-    console.log('Fetching profession tags from API...');
-    const response = await apiClient.get<User>('/users/profile/');
     if (response.error) {
-      console.error('API error:', response.error);
       throw new Error(response.error);
     }
-    console.log('API response:', response.data);
-    // Extract profession tags from user profile - the API returns 'tags' not 'profession_tags'
-    const tags = response.data?.tags || [];
-    console.log('Extracted profession tags:', tags);
-    return tags;
+  },
+
+  async getProfessionTags(): Promise<ProfessionTag[]> {
+    const profile = await this.getMyProfile(true);
+    return profile.tags || [];
   },
 
   async setProfessionTags(tags: { name: string; verified?: boolean }[]): Promise<ProfessionTag[]> {
-    console.log('Setting profession tags:', tags);
-    const response = await apiClient.post<ProfessionTag[]>('/users/tag/set/', tags);
+    const response = await apiClient.post<any[]>('/users/tag/set/', tags);
     if (response.error) {
-      console.error('API error setting tags:', response.error);
       throw new Error(response.error);
     }
-    console.log('API response for set tags:', response.data);
-    return response.data!;
+
+    const updatedTags = Array.isArray(response.data) ? response.data : [];
+    return updatedTags.map(normalizeTagResponse);
   },
 
   async uploadCertificate(tagId: number, fileUri: string, fileName: string): Promise<ProfessionTag> {
-    console.log('Uploading certificate for tag:', tagId, 'File:', fileName);
-    // Get auth token
     const token = await AsyncStorage.getItem('access_token');
     if (!token) {
       throw new Error('No authentication token found');
     }
 
-    // Create FormData
     const formData = new FormData();
     const file = {
       uri: fileUri,
       name: fileName,
-      type: fileName.toLowerCase().endsWith('.pdf') ? 'application/pdf' : 
-            fileName.toLowerCase().endsWith('.png') ? 'image/png' : 
-            fileName.toLowerCase().endsWith('.jpg') || fileName.toLowerCase().endsWith('.jpeg') ? 'image/jpeg' : 'application/octet-stream',
+      type: fileName.toLowerCase().endsWith('.pdf')
+        ? 'application/pdf'
+        : fileName.toLowerCase().endsWith('.png')
+          ? 'image/png'
+          : fileName.toLowerCase().endsWith('.jpg') || fileName.toLowerCase().endsWith('.jpeg')
+            ? 'image/jpeg'
+            : 'application/octet-stream',
     };
-    
+
     formData.append('certificate', file as any);
     formData.append('tag_id', tagId.toString());
 
-    try {
-      console.log('Sending certificate upload request...');
-      const response = await fetch(`${API_CONFIG.BASE_URL}/users/certificate/`, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
-        body: formData,
-      });
+    const response = await fetch(`${API_CONFIG.BASE_URL}/users/certificate/`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      body: formData,
+    });
 
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error('Certificate upload failed:', response.status, errorText);
-        throw new Error(`Certificate upload failed: ${response.status} - ${errorText}`);
-      }
-
-      const data = await response.json();
-      console.log('Certificate upload successful:', data);
-      return data as ProfessionTag;
-    } catch (error) {
-      console.error('Certificate upload error:', error);
-      throw error;
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Certificate upload failed: ${response.status} - ${errorText}`);
     }
+
+    const data = await response.json();
+    return normalizeTagResponse(data);
   },
 
-  // Get other user's profile with profession tags
-  async getOtherUserProfile(username: string): Promise<User> {
-    const response = await apiClient.get<User>(`/users/${encodeURIComponent(username)}/profile/`);
-    if (response.error) throw new Error(response.error);
-    
-    // Convert relative profile_image URL to full URL
-    if (response.data?.profile_image && !response.data.profile_image.startsWith('http')) {
-      const baseUrl = 'https://nutrihub.fit';
-      response.data.profile_image = `${baseUrl}${response.data.profile_image}`;
+  async getOtherUserProfile(username: string, userId?: number): Promise<User> {
+    const users = await listUsers();
+    const user = findUser(users, { username, userId });
+    if (!user) {
+      throw new Error('User not found');
     }
-    
-    return response.data!;
+    return user;
   },
 
   async removeCertificate(tagId: number): Promise<ProfessionTag> {
-    console.log('Removing certificate for tag:', tagId);
-    // Get auth token
     const token = await AsyncStorage.getItem('access_token');
     if (!token) {
       throw new Error('No authentication token found');
     }
 
-    try {
-      console.log('Sending certificate removal request...');
-      const response = await fetch(`${API_CONFIG.BASE_URL}/users/certificate/`, {
-        method: 'DELETE',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ tag_id: tagId }),
-      });
+    const response = await fetch(`${API_CONFIG.BASE_URL}/users/certificate/`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ tag_id: tagId }),
+    });
 
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error('Certificate removal failed:', response.status, errorText);
-        throw new Error(`Certificate removal failed: ${response.status} - ${errorText}`);
-      }
-
-      const data = await response.json();
-      console.log('Certificate removal successful:', data);
-      return data as ProfessionTag;
-    } catch (error) {
-      console.error('Certificate removal error:', error);
-      throw error;
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Certificate removal failed: ${response.status} - ${errorText}`);
     }
+
+    const data = await response.json();
+    return normalizeTagResponse(data);
   },
 };
-
-

--- a/mobile/nutrihub/src/types/types.ts
+++ b/mobile/nutrihub/src/types/types.ts
@@ -111,6 +111,15 @@ export interface Recipe {
 }
 
 /**
+ * Lightweight recipe data returned on user profiles
+ */
+export interface UserRecipeSummary {
+  id: number;
+  name: string;
+  ingredients?: RecipeIngredient[];
+}
+
+/**
  * Recipe ingredient model
  */
 export interface RecipeIngredient {
@@ -129,20 +138,19 @@ export interface User {
   name?: string;
   surname?: string;
   address?: string;
-  tags?: ProfessionTag[]; // Backend returns tags as ProfessionTag array
-  allergens?: string[];
+  tags?: ProfessionTag[];
+  allergens?: Allergen[];
+  recipes?: UserRecipeSummary[];
   createdAt?: Date;
-  // Optional public profile fields
-  profile_image?: string; // URL - matches backend field name
+  profile_image?: string | null;
   profession?: string;
   bio?: string;
   badges?: string[];
-  // Enhanced profile fields
   phone?: string;
   location?: string;
   website?: string;
   social_links?: SocialLink[];
-  profession_tags?: ProfessionTag[]; // Keep for compatibility
+  profession_tags?: ProfessionTag[];
   custom_allergens?: string[];
   privacy_settings?: PrivacySettings;
   account_warnings?: AccountWarning[];
@@ -162,12 +170,8 @@ export interface SocialLink {
 export interface ProfessionTag {
   id: number;
   name: string;
-  is_verified: boolean;
-  certificate_url?: string;
-  certificate_name?: string;
-  created_at: Date;
-  verified_at?: Date;
-  verified_by?: string;
+  verified: boolean;
+  certificate?: string | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Align the public “User Profile” view with the polished layout used on `MyProfileScreen`, including card-based sections and consistent styling.
- Respect profile privacy settings for posts, recipes, badges, profession tags, and contact info while still surfacing owner-only controls.
- Refactor mobile user-service models to normalize backend payloads (tags, recipes, profile images) and add cache-busting so profile photo edits propagate correctly.
- Update supporting profile screens to consume the new `ProfessionTag` shape and use the refreshed user-service utilities.

## Details
- Rebuilt `UserProfileScreen` header to match the “My Profile” card UI, added stats/section cards, and moved the tabs into a dedicated container while keeping existing data/behaviour.
- Added recipe and badge visibility messaging, tightened liked-post tab conditions, and improved empty-state copy to differentiate between “private” vs “no content”.
- Normalized `user.service` responses (tags, recipes, profile image URLs); added cache-busting for images, refreshed `getMyProfile`, and ensured profession tags/recipes are exposed consistently.
- Updated types (`ProfessionTag`, `User`, `UserRecipeSummary`) and all screens that reference profession tags so they use the new properties (`verified`, `certificate`).
- Tweaked `ProfileSettingsScreen`, `MyPostsScreen`, and `ProfessionTagsScreen` to reflect the new tag shape and keep UI badges accurate.