### PR TITLE
fix: revert likes/posts polling

### DIFF
--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -96,17 +96,9 @@ const Profile = () => {
         loadLikedRecipes()
       }
     })
-    
-    // Also poll every 5 seconds to sync changes from other devices and refresh like counts
-    const intervalId = window.setInterval(() => {
-      // Refresh liked posts and recipes to get updated like counts
-      loadLikedPosts()
-      loadLikedRecipes()
-    }, 5000)
 
     return () => {
       unsubscribe()
-      clearInterval(intervalId)
     }
   }, [])
 

--- a/frontend/src/pages/forum/Forum.tsx
+++ b/frontend/src/pages/forum/Forum.tsx
@@ -158,38 +158,8 @@ const Forum = () => {
             setAllPosts(prev => prev.map(p => p.id === event.postId ? { ...p, liked: event.isLiked, likes: event.likeCount } : p));
         });
 
-        // Poll server every 5 seconds to refresh posts and keep everything in sync
-        const intervalId = window.setInterval(async () => {
-            try {
-                // Fetch the latest posts from server
-                const params = {
-                    ordering: '-created_at',
-                    page: 1,
-                    page_size: 500
-                };
-                const response = await apiClient.getForumPosts(params);
-                
-                // Get current liked posts from server
-                const likedMapFromServer = await fetchAndSyncLikedPostsFromServer();
-                
-                // Merge server data with liked status
-                const updatedPosts = response.results.map(post => ({
-                    ...post,
-                    author: post.author || { id: 0, username: 'Anonymous' },
-                    liked: likedMapFromServer[post.id] !== undefined ? likedMapFromServer[post.id] : (post.liked || false),
-                }));
-                
-                // Update state
-                setAllPosts(updatedPosts);
-                setLikedPosts(likedMapFromServer);
-            } catch {
-                // ignore polling errors silently
-            }
-        }, 5000);
-
         return () => {
             unsubscribe();
-            clearInterval(intervalId);
         };
     }, [location, username, navigate]);
     


### PR DESCRIPTION
Polling was introduced to keep profile view updated, but it is excessive for what it tries to achieve. And, it seems to break pagination in forum.

Close #543