### PR TITLE
fix: Removed unused imports and variables in Selenium tests

### DIFF
--- a/frontend/src/test/selenium/CreatePost.selenium.test.ts
+++ b/frontend/src/test/selenium/CreatePost.selenium.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { WebDriver, By, until } from 'selenium-webdriver';
+import { WebDriver, By } from 'selenium-webdriver';
 import { getDriver, quitDriver, defaultConfig, loginWithTestCredentials } from './selenium.config';
 
 describe('Create Post Page - Selenium E2E Tests', () => {

--- a/frontend/src/test/selenium/FoodProposal.selenium.test.ts
+++ b/frontend/src/test/selenium/FoodProposal.selenium.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { WebDriver, By, until } from 'selenium-webdriver';
+import { WebDriver, By } from 'selenium-webdriver';
 import { getDriver, quitDriver, defaultConfig, loginWithTestCredentials } from './selenium.config';
 
 describe('Food Proposal - Selenium E2E Tests', () => {

--- a/frontend/src/test/selenium/MealPlanner.selenium.test.ts
+++ b/frontend/src/test/selenium/MealPlanner.selenium.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { WebDriver, By, until } from 'selenium-webdriver';
+import { WebDriver, By } from 'selenium-webdriver';
 import { getDriver, quitDriver, defaultConfig, loginWithTestCredentials } from './selenium.config';
 
 describe('Meal Planner Page - Selenium E2E Tests', () => {

--- a/frontend/src/test/selenium/MealPlannerActions.selenium.test.ts
+++ b/frontend/src/test/selenium/MealPlannerActions.selenium.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { WebDriver, By, until } from 'selenium-webdriver';
+import { WebDriver, By } from 'selenium-webdriver';
 import { getDriver, quitDriver, defaultConfig, loginWithTestCredentials } from './selenium.config';
 
 describe('Meal Planner Actions - Selenium E2E Tests', () => {

--- a/frontend/src/test/selenium/PostInteraction.selenium.test.ts
+++ b/frontend/src/test/selenium/PostInteraction.selenium.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { WebDriver, By, until } from 'selenium-webdriver';
+import { WebDriver, By } from 'selenium-webdriver';
 import { getDriver, quitDriver, defaultConfig, loginWithTestCredentials } from './selenium.config';
 
 describe('Post Interaction - Selenium E2E Tests', () => {
@@ -51,9 +51,7 @@ describe('Post Interaction - Selenium E2E Tests', () => {
     );
     
     if (likeButtons.length > 0) {
-      // Get initial state
-      const initialState = await likeButtons[0].getAttribute('aria-pressed');
-      
+
       // Click like button
       await likeButtons[0].click();
       await driver.sleep(1000);
@@ -136,8 +134,6 @@ describe('Post Interaction - Selenium E2E Tests', () => {
     );
     
     if (likeButtons.length > 0) {
-      // Get initial class/style
-      const initialClass = await likeButtons[0].getAttribute('class');
       
       // Click like
       await likeButtons[0].click();

--- a/frontend/src/test/selenium/Profile.selenium.test.ts
+++ b/frontend/src/test/selenium/Profile.selenium.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { WebDriver, By, until } from 'selenium-webdriver';
+import { WebDriver, By } from 'selenium-webdriver';
 import { getDriver, quitDriver, defaultConfig, loginWithTestCredentials } from './selenium.config';
 
 describe('Profile Page - Selenium E2E Tests', () => {

--- a/frontend/src/test/selenium/RecipeCreation.selenium.test.ts
+++ b/frontend/src/test/selenium/RecipeCreation.selenium.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { WebDriver, By, until } from 'selenium-webdriver';
+import { WebDriver, By } from 'selenium-webdriver';
 import { getDriver, quitDriver, defaultConfig, loginWithTestCredentials } from './selenium.config';
 
 describe('Recipe Creation - Selenium E2E Tests', () => {

--- a/frontend/src/test/selenium/ThemeToggle.selenium.test.ts
+++ b/frontend/src/test/selenium/ThemeToggle.selenium.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { WebDriver, By, until } from 'selenium-webdriver';
+import { WebDriver, By } from 'selenium-webdriver';
 import { getDriver, quitDriver, defaultConfig, loginWithTestCredentials } from './selenium.config';
 
 describe('Theme Toggle - Selenium E2E Tests', () => {
@@ -66,7 +66,6 @@ describe('Theme Toggle - Selenium E2E Tests', () => {
     await driver.sleep(500);
 
     const htmlElement = await driver.findElement(By.xpath("//html"));
-    const initialClass = await htmlElement.getAttribute('class');
 
     // Find and click theme toggle
     const themeButtons = await driver.findElements(

--- a/frontend/src/test/selenium/UserFlow.selenium.test.ts
+++ b/frontend/src/test/selenium/UserFlow.selenium.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { WebDriver, By, until } from 'selenium-webdriver';
+import { WebDriver, By } from 'selenium-webdriver';
 import { getDriver, quitDriver, defaultConfig, loginWithTestCredentials } from './selenium.config';
 
 describe('User Flow - Selenium E2E Tests', () => {


### PR DESCRIPTION
The unused imports and variables caused `docker-compose --build up` to fail.

You can review which imports and variables removed.

fixes #616 