### PR TITLE
Fix profile photo cache issue in mobile app

### DIFF
--- a/mobile/nutrihub/src/screens/user/MyProfileScreen.tsx
+++ b/mobile/nutrihub/src/screens/user/MyProfileScreen.tsx
@@ -217,13 +217,25 @@ const MyProfileScreen: React.FC = () => {
                     const name = localUri.split('/').pop() || 'profile.jpg';
                     const res = await userService.uploadProfilePhoto(localUri, name);
 
-                    setUserProfile(prev => prev ? { ...prev, profile_image: res.profile_image } : prev);
+                    // Add cache-busting parameter to force image reload
+                    const cacheBustedUrl = res.profile_image 
+                      ? `${res.profile_image}${res.profile_image.includes('?') ? '&' : '?'}t=${Date.now()}`
+                      : res.profile_image;
+                    
+                    setUserProfile(prev => prev ? { ...prev, profile_image: cacheBustedUrl } : prev);
                     
                     try {
                       const refreshed = await userService.getMyProfile(true);
-                      setUserProfile(refreshed);
+                      // Add cache-busting parameter to the refreshed profile image too
+                      const refreshedWithCache = {
+                        ...refreshed,
+                        profile_image: refreshed.profile_image 
+                          ? `${refreshed.profile_image}${refreshed.profile_image.includes('?') ? '&' : '?'}t=${Date.now()}`
+                          : refreshed.profile_image
+                      };
+                      setUserProfile(refreshedWithCache);
                       // Also update the AuthContext
-                      updateUser(refreshed);
+                      updateUser(refreshedWithCache);
                     } catch (refreshError) {
                       console.warn('Failed to refresh profile after upload', refreshError);
                     }

--- a/mobile/nutrihub/src/screens/user/ProfileSettingsScreen.tsx
+++ b/mobile/nutrihub/src/screens/user/ProfileSettingsScreen.tsx
@@ -136,8 +136,13 @@ const ProfileSettingsScreen: React.FC = () => {
       const name = uri.split('/').pop() || 'profile.jpg';
       const res = await userService.uploadProfilePhoto(uri, name);
       
+      // Add cache-busting parameter to force image reload
+      const cacheBustedUrl = res.profile_image 
+        ? `${res.profile_image}${res.profile_image.includes('?') ? '&' : '?'}t=${Date.now()}`
+        : res.profile_image;
+      
       // Update local state with the server response
-      setUser(prev => prev ? { ...prev, profile_image: res.profile_image } : prev);
+      setUser(prev => prev ? { ...prev, profile_image: cacheBustedUrl } : prev);
     } catch (error) {
       console.error('Error uploading profile photo:', error);
       Alert.alert('Error', 'Failed to upload profile photo');


### PR DESCRIPTION
## 🐛 Bug Fix: Profile Photo Cache Issue in Mobile App

**Fixes #648**

### 📋 Description
Fixed a bug where the mobile app displayed an old profile photo after uploading a new one, even though the correct photo was successfully uploaded to the server and visible on the web application.

### 🔍 Root Cause
The backend stores profile images using UUID-based filenames that remain the same for each user. When a new photo is uploaded, it replaces the old file but keeps the same URL. React Native's `Image` component caches images by URL, so it continued displaying the cached old image instead of fetching the new one.

### ✅ Solution
Added cache-busting query parameters (timestamps) to image URLs after upload. This forces React Native to treat the URL as new and fetch the updated image from the server.

###Example
Before: https://server.com/media/profile_images/uuid.jpg
After: https://server.com/media/profile_images/uuid.jpg?t=1732189585123


### 📝 Changes Made
- Updated `MyProfileScreen.tsx` to add cache-busting parameters after photo upload
- Updated `ProfileSettingsScreen.tsx` with the same cache-busting logic
- Added comprehensive Jest tests for `uploadProfilePhoto`, `removeProfilePhoto`, and `getMyProfile` functions
- All 23 tests passing ✅

### 🧪 Testing
- ✅ Unit tests added and passing (23 tests)
- ✅ Manually tested photo upload on mobile - displays correct image immediately
- ✅ Verified consistency across multiple consecutive uploads

### 📸 Files Changed
- `mobile/nutrihub/src/screens/user/MyProfileScreen.tsx`
- `mobile/nutrihub/src/screens/user/ProfileSettingsScreen.tsx`
- `mobile/nutrihub/__tests__/user.service.test.ts`
