### PR TITLE
feat: Integrate liked posts API and update filters (#699)

### DIFF
--- a/mobile/nutrihub/src/screens/user/LikedPostsScreen.tsx
+++ b/mobile/nutrihub/src/screens/user/LikedPostsScreen.tsx
@@ -17,6 +17,8 @@ import { useTheme } from '../../context/ThemeContext';
 import { SPACING, BORDER_RADIUS } from '../../constants/theme';
 import { ForumTopic } from '../../types/types';
 import ForumPost from '../../components/forum/ForumPost';
+import { forumService } from '../../services/api/forum.service';
+import { useFocusEffect } from '@react-navigation/native';
 
 const LikedPostsScreen: React.FC = () => {
   const { theme, textStyles } = useTheme();
@@ -25,77 +27,30 @@ const LikedPostsScreen: React.FC = () => {
   const [likedPosts, setLikedPosts] = useState<ForumTopic[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [filter, setFilter] = useState<'all' | 'recipes' | 'tips' | 'questions'>('all');
+  const [filter, setFilter] = useState<'all' | 'recipe' | 'dietary-tip' | 'meal-plan'>('all');
 
   // Load user's liked posts on mount
   useEffect(() => {
     loadLikedPosts();
   }, []);
 
+  // Refresh data when screen comes into focus
+  useFocusEffect(
+    useCallback(() => {
+      loadLikedPosts();
+    }, [])
+  );
+
   const loadLikedPosts = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      // TODO: Replace with actual API call
-      // const likedPostsData = await forumService.getLikedPosts();
-      // setLikedPosts(likedPostsData);
-      
-      // Mock data for now
-      const mockLikedPosts: ForumTopic[] = [
-        {
-          id: 1,
-          title: 'Amazing Healthy Breakfast Ideas',
-          content: 'Here are some fantastic healthy breakfast recipes that will start your day right. These recipes are packed with nutrients and are easy to make...',
-          author: 'nutrition_expert',
-          authorId: 1,
-          commentsCount: 15,
-          likesCount: 42,
-          isLiked: true,
-          tags: ['recipe', 'breakfast', 'healthy'],
-          createdAt: new Date('2024-01-15T10:00:00Z'),
-        },
-        {
-          id: 2,
-          title: 'Nutrition Tips for Beginners',
-          content: 'Starting your nutrition journey? Here are some essential tips to help you get started on the right track...',
-          author: 'health_coach',
-          authorId: 2,
-          commentsCount: 8,
-          likesCount: 25,
-          isLiked: true,
-          tags: ['nutrition', 'tips', 'beginner'],
-          createdAt: new Date('2024-01-10T14:30:00Z'),
-        },
-        {
-          id: 3,
-          title: 'Best Protein Sources for Vegetarians',
-          content: 'Looking for plant-based protein options? Here are some excellent sources of protein for vegetarians...',
-          author: 'veggie_chef',
-          authorId: 3,
-          commentsCount: 12,
-          likesCount: 38,
-          isLiked: true,
-          tags: ['protein', 'vegetarian', 'nutrition'],
-          createdAt: new Date('2024-01-08T09:15:00Z'),
-        },
-        {
-          id: 4,
-          title: 'How to Meal Prep Like a Pro',
-          content: 'Meal prepping can save you time and help you stick to your nutrition goals. Here are some pro tips...',
-          author: 'meal_prep_master',
-          authorId: 4,
-          commentsCount: 20,
-          likesCount: 67,
-          isLiked: true,
-          tags: ['meal-prep', 'tips', 'organization'],
-          createdAt: new Date('2024-01-05T16:45:00Z'),
-        }
-      ];
-      
-      setLikedPosts(mockLikedPosts);
-    } catch (err) {
+      const likedPostsData = await forumService.getLikedPosts();
+      setLikedPosts(likedPostsData);
+    } catch (err: any) {
       console.error('Error loading liked posts:', err);
-      setError('Failed to load your liked posts');
+      const errorMessage = err?.message || 'Failed to load your liked posts';
+      setError(errorMessage);
     } finally {
       setLoading(false);
     }
@@ -112,12 +67,14 @@ const LikedPostsScreen: React.FC = () => {
 
   const handleUnlikePost = async (postId: number) => {
     try {
-      // TODO: Replace with actual API call
-      // await forumService.unlikePost(postId);
+      // Use toggleLike to unlike the post (it toggles, so if it's liked, it will unlike)
+      await forumService.toggleLike(postId);
       
+      // Remove from local state
       setLikedPosts(prev => prev.filter(post => post.id !== postId));
       Alert.alert('Success', 'Post removed from your liked posts');
     } catch (error) {
+      console.error('Error unliking post:', error);
       Alert.alert('Error', 'Failed to unlike post. Please try again.');
     }
   };
@@ -128,12 +85,12 @@ const LikedPostsScreen: React.FC = () => {
     return likedPosts.filter(post => {
       const tags = post.tags || [];
       switch (filter) {
-        case 'recipes':
-          return tags.some(tag => tag.toLowerCase().includes('recipe'));
-        case 'tips':
-          return tags.some(tag => tag.toLowerCase().includes('tip'));
-        case 'questions':
-          return tags.some(tag => tag.toLowerCase().includes('question'));
+        case 'recipe':
+          return tags.some(tag => tag.toLowerCase() === 'recipe');
+        case 'dietary-tip':
+          return tags.some(tag => tag.toLowerCase() === 'dietary tip' || tag.toLowerCase() === 'nutrition tip');
+        case 'meal-plan':
+          return tags.some(tag => tag.toLowerCase() === 'meal plan' || tag.toLowerCase() === 'mealplan');
         default:
           return true;
       }
@@ -173,26 +130,55 @@ const LikedPostsScreen: React.FC = () => {
     </View>
   );
 
-  const renderEmptyState = () => (
-    <View style={styles.emptyState}>
-      <Icon name="heart-outline" size={64} color={theme.textSecondary} />
-      <Text style={[textStyles.heading4, { color: theme.text, marginTop: SPACING.md }]}>
-        No Liked Posts Yet
-      </Text>
-      <Text style={[textStyles.body, { color: theme.textSecondary, textAlign: 'center', marginTop: SPACING.sm }]}>
-        Posts you like will appear here. Start exploring the forum to find interesting content!
-      </Text>
-      <TouchableOpacity
-        style={[styles.exploreButton, { backgroundColor: theme.primary }]}
-        onPress={() => navigation.navigate('Forum' as never)}
-      >
-        <Icon name="forum" size={20} color="#fff" />
-        <Text style={[textStyles.body, { color: '#fff', fontWeight: '600', marginLeft: SPACING.xs }]}>
-          Explore Forum
+  const renderEmptyState = () => {
+    const getEmptyStateMessage = () => {
+      switch (filter) {
+        case 'recipe':
+          return {
+            title: 'No Liked Recipes Yet',
+            message: 'Recipes you like will appear here. Start exploring the forum to find interesting recipes!'
+          };
+        case 'dietary-tip':
+          return {
+            title: 'No Liked Dietary Tips Yet',
+            message: 'Dietary tips you like will appear here. Start exploring the forum to find helpful tips!'
+          };
+        case 'meal-plan':
+          return {
+            title: 'No Liked Meal Plans Yet',
+            message: 'Meal plans you like will appear here. Start exploring the forum to find meal plans!'
+          };
+        default:
+          return {
+            title: 'No Liked Posts Yet',
+            message: 'Posts you like will appear here. Start exploring the forum to find interesting content!'
+          };
+      }
+    };
+
+    const { title, message } = getEmptyStateMessage();
+
+    return (
+      <View style={styles.emptyState}>
+        <Icon name="heart-outline" size={64} color={theme.textSecondary} />
+        <Text style={[textStyles.heading4, { color: theme.text, marginTop: SPACING.md }]}>
+          {title}
         </Text>
-      </TouchableOpacity>
-    </View>
-  );
+        <Text style={[textStyles.body, { color: theme.textSecondary, textAlign: 'center', marginTop: SPACING.sm }]}>
+          {message}
+        </Text>
+        <TouchableOpacity
+          style={[styles.exploreButton, { backgroundColor: theme.primary }]}
+          onPress={() => navigation.navigate('Forum' as never)}
+        >
+          <Icon name="forum" size={20} color="#fff" />
+          <Text style={[textStyles.body, { color: '#fff', fontWeight: '600', marginLeft: SPACING.xs }]}>
+            Explore Forum
+          </Text>
+        </TouchableOpacity>
+      </View>
+    );
+  };
 
   if (loading) {
     return (
@@ -244,9 +230,9 @@ const LikedPostsScreen: React.FC = () => {
       <View style={[styles.filterContainer, { backgroundColor: theme.surface, borderBottomColor: theme.border }]}>
         <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.filterButtons}>
           {renderFilterButton('all', 'All', 'format-list-bulleted')}
-          {renderFilterButton('recipes', 'Recipes', 'chef-hat')}
-          {renderFilterButton('tips', 'Tips', 'lightbulb')}
-          {renderFilterButton('questions', 'Questions', 'help-circle')}
+          {renderFilterButton('recipe', 'Recipe', 'chef-hat')}
+          {renderFilterButton('dietary-tip', 'Dietary Tip', 'lightbulb')}
+          {renderFilterButton('meal-plan', 'Meal Plan', 'calendar-check')}
         </ScrollView>
       </View>
 

--- a/mobile/nutrihub/src/screens/user/MyPostsScreen.tsx
+++ b/mobile/nutrihub/src/screens/user/MyPostsScreen.tsx
@@ -43,13 +43,6 @@ const MyPostsScreen: React.FC = () => {
       screen: 'LikedPosts'
     },
     {
-      id: 'liked-recipes',
-      title: 'Liked Recipes',
-      description: 'View recipes you have liked',
-      icon: 'heart-outline',
-      screen: 'LikedRecipes'
-    },
-    {
       id: 'personal-recipes',
       title: 'Personal Recipes',
       description: 'View and manage your personal recipe collection',

--- a/mobile/nutrihub/src/services/api/forum.service.ts
+++ b/mobile/nutrihub/src/services/api/forum.service.ts
@@ -559,5 +559,44 @@ export const forumService = {
     );
     
     return mappedPosts;
+  },
+
+  /**
+   * Get posts that the current user has liked
+   * @returns Array of ForumTopic objects
+   */
+  async getLikedPosts(): Promise<ForumTopic[]> {
+    // Check for token before making the request
+    const accessToken = await AsyncStorage.getItem('access_token');
+    if (!accessToken) {
+      console.log("Skipping liked posts request - no access token available");
+      return [];
+    }
+    
+    const response = await apiClient.get<PaginatedResponse<ApiForumTopic>>('/users/profile/liked-posts/');
+    if (response.error) {
+      if (response.status === 401) {
+        console.error("Authentication error in getLikedPosts - token may be invalid");
+        throw new Error("Authentication error - please login again");
+      }
+      throw new Error(response.error);
+    }
+    
+    if (!response.data || !response.data.results) {
+      console.error('Unexpected liked posts response format:', response.data);
+      return [];
+    }
+    
+    // Map posts and ensure isLiked is true for all liked posts
+    const mappedPosts = await Promise.all(
+      response.data.results.map(async (apiTopic) => {
+        const topic = await mapApiTopicToForumTopic(apiTopic);
+        // Ensure isLiked is true since these are all liked posts
+        topic.isLiked = true;
+        return topic;
+      })
+    );
+    
+    return mappedPosts;
   }
 };


### PR DESCRIPTION
# 🔗 Liked Posts API Integration and Filter Updates

## Overview
This PR replaces mock data in LikedPostsScreen with real API integration, updates filters to use project-specific post types, and removes redundant Liked Recipes section from MyPostsScreen.

## 🎯 Key Features

### API Integration
- ✅ **Real Data**: Replaced mock data with actual API calls to `/users/profile/liked-posts/`
- ✅ **Auto-Refresh**: Added `useFocusEffect` to refresh data when screen comes into focus
- ✅ **Error Handling**: Improved error handling with user-friendly messages
- ✅ **Unlike Functionality**: Integrated with existing `toggleLike` API for unliking posts

### Filter Updates
- ✅ **Project-Specific Filters**: Changed from generic filters to actual post types:
  - All Posts
  - Recipe
  - Dietary Tip
  - Meal Plan
- ✅ **Accurate Filtering**: Filters now match exact tag names from backend
- ✅ **Dynamic Empty States**: Empty state messages change based on selected filter:
  - "No Liked Posts Yet" (All)
  - "No Liked Recipes Yet" (Recipe)
  - "No Liked Dietary Tips Yet" (Dietary Tip)
  - "No Liked Meal Plans Yet" (Meal Plan)

### UI Improvements
- ✅ **Removed Redundancy**: Removed "Liked Recipes" section from MyPostsScreen since LikedPostsScreen handles all liked posts with filtering
- ✅ **Better UX**: Context-aware empty states provide clearer guidance to users

## 🔧 Technical Changes

### Core Components
- **`LikedPostsScreen.tsx`**: 
  - Removed all mock data
  - Integrated `forumService.getLikedPosts()` API call
  - Updated filter types to match project post types
  - Added dynamic empty state messages
  - Added `useFocusEffect` for auto-refresh
  - Updated `handleUnlikePost` to use real API

- **`MyPostsScreen.tsx`**: 
  - Removed "Liked Recipes" section item
  - Simplified navigation structure

### API Service
- **`forum.service.ts`**: 
  - Added `getLikedPosts()` method
  - Handles paginated responses from `/users/profile/liked-posts/`
  - Maps API response to `ForumTopic` format
  - Ensures `isLiked` is true for all returned posts
  - Handles authentication errors gracefully

## 🧪 Testing

### Manual Testing
- ✅ Verified liked posts are fetched from API correctly
- ✅ Tested all filter buttons (All, Recipe, Dietary Tip, Meal Plan)
- ✅ Verified empty states show correct messages for each filter
- ✅ Tested unlike functionality
- ✅ Verified auto-refresh when navigating to screen
- ✅ Tested error handling for network failures
- ✅ Verified MyPostsScreen no longer shows Liked Recipes section

## 📊 Statistics
- **3 files changed**
- **115 insertions**, **97 deletions**
- **1 new API method** (`getLikedPosts`)

## 🔗 Related Issues
Closes #699

## ✅ Checklist
- [x] Code follows project style guidelines
- [x] No console errors or warnings
- [x] API integration verified
- [x] Filters match project post types
- [x] Empty states are dynamic and context-aware
- [x] Removed redundant Liked Recipes section
- [x] Auto-refresh on screen focus
- [x] Error handling implemented

## 📝 Notes
- The implementation uses the existing forum service infrastructure
- Filters match exact tag names from the backend (case-insensitive)
- All liked posts are automatically marked as `isLiked: true`
- The unlike functionality uses the existing `toggleLike` API endpoint

## 🚀 Testing Instructions
1. Navigate to Profile Settings → My Posts & Content → Liked Posts
2. Verify liked posts are loaded from the API (not mock data)
3. Test each filter button:
   - All: Shows all liked posts
   - Recipe: Shows only posts with "Recipe" tag
   - Dietary Tip: Shows only posts with "Dietary tip" or "Nutrition Tip" tags
   - Meal Plan: Shows only posts with "Meal Plan" or "Mealplan" tags
4. Verify empty state messages change based on selected filter
5. Test unlike functionality by clicking unlike on a post
6. Navigate away and back to verify auto-refresh works
7. Verify MyPostsScreen no longer shows "Liked Recipes" section
