### PR TITLE
ops: add mobile apk build Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,36 @@ Note: The API credentials are required for:
 - Nutritional information retrieval
 - Food database integration
 
+## Building Android APK with Docker
+
+### Prerequisites
+
+- Docker with at least 8GB RAM allocated, gradle build fails with OOM otherwise
+
+### Build Instructions
+
+```bash
+cd mobile/nutrihub
+
+# Build the Docker image
+docker build -t nutrihub-apk .
+
+# Create a temporary container
+docker create --name nutrihub-temp nutrihub-apk
+
+# Extract the APK
+docker cp nutrihub-temp:/app/android/app/build/outputs/apk/release/app-release.apk ./nutrihub.apk
+
+# Clean up
+docker rm nutrihub-temp
+```
+
+### Troubleshooting
+
+**If build fails with "Gradle daemon disappeared":**
+- Increase Docker memory to 8GB+ in Docker settings
+- Restart Docker
+
 ## Manual Setup
 
 ### Backend Setup

--- a/mobile/nutrihub/Dockerfile
+++ b/mobile/nutrihub/Dockerfile
@@ -1,0 +1,28 @@
+FROM --platform=linux/amd64 mobiledevops/android-sdk-image:latest
+
+# Install Node.js
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+COPY . .
+RUN npm install
+
+
+# Generate native Android code
+RUN npx expo prebuild --platform android --clean
+
+# Configure Gradle memory settings
+WORKDIR /app/android
+RUN echo "org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError" >> gradle.properties && \
+    echo "org.gradle.daemon=false" >> gradle.properties && \
+    echo "org.gradle.parallel=false" >> gradle.properties
+
+# Build the release APK
+RUN ./gradlew assembleRelease --stacktrace
+
+# APK will be at: /app/android/app/build/outputs/apk/release/app-release.apk
+CMD ["echo", "APK built successfully at /app/android/app/build/outputs/apk/release/app-release.apk"]


### PR DESCRIPTION
Close #658 

This is different from [#672](https://github.com/bounswe/bounswe2025group9/pull/672), it builds apk in a containerized environment. Gradle build takes lots of memory, I wouldn't recommend using this in an actual built workflow.
Just use following:
```
cd mobile/nutrihub/
RUN npx expo prebuild --platform android --clean
cd android
./gradlew assembleRelease
```
in the end the apk is at `android/app/build/outputs/apk/release/app-release.apk`
