### PR TITLE
Schema.org/recipe Compatible Recipe Description endpoint for external integrations.

### DIFF
--- a/backend/forum/urls.py
+++ b/backend/forum/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import CommentViewSet, PostViewSet, TagViewSet, RecipeViewSet
+from .views import CommentViewSet, PostViewSet, TagViewSet, RecipeViewSet, recipe_schema_json_view
 from .admin import PostModerationViewSet, CommentModerationViewSet
 
 router = DefaultRouter()
@@ -20,4 +20,5 @@ moderation_router.register(
 urlpatterns = [
     path("", include(router.urls)),
     path("moderation/", include(moderation_router.urls), name="moderation"),
+    path("recipe/<int:pk>/schema/", recipe_schema_json_view, name="recipe-schema"),
 ]

--- a/backend/forum/views.py
+++ b/backend/forum/views.py
@@ -1,9 +1,11 @@
 from django_filters.rest_framework import DjangoFilterBackend
+from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
 from rest_framework.response import Response
 from rest_framework import status
 from rest_framework import viewsets, permissions, mixins
 from rest_framework.filters import OrderingFilter
-from rest_framework.decorators import action
+from rest_framework.decorators import action, api_view, permission_classes
 from fuzzywuzzy import fuzz
 import logging
 
@@ -241,3 +243,96 @@ class RecipeViewSet(viewsets.ModelViewSet):
                 "You can only add recipes to your own posts."
             )
         serializer.save()
+
+
+@api_view(['GET'])
+@permission_classes([permissions.AllowAny])  # Public endpoint for SEO
+def recipe_schema_json_view(request, pk):
+    """
+    Returns a rich Schema.org compatible JSON-LD representation of a Recipe.
+    This endpoint maximizes data output by inferring additional fields from existing data.
+    This endpoint is publicly accessible for external services.
+    """
+    recipe = get_object_or_404(
+        Recipe.objects.select_related('post__author')
+        .prefetch_related('ingredients__food', 'post__tags'), 
+        pk=pk
+    )
+    
+    # Build recipeIngredient list
+    recipe_ingredients = []
+    for ingredient in recipe.ingredients.all():
+        # Format: "{customAmount}{customUnit} of {food.name}"
+        ingredient_str = f"{ingredient.customAmount}{ingredient.customUnit} of {ingredient.food.name}"
+        recipe_ingredients.append(ingredient_str)
+    
+    # Build nutrition object
+    nutrition = {
+        "@type": "NutritionInformation",
+        "calories": f"{recipe.total_calories:.1f} calories",
+        "proteinContent": f"{recipe.total_protein:.1f}g",
+        "fatContent": f"{recipe.total_fat:.1f}g",
+        "carbohydrateContent": f"{recipe.total_carbohydrates:.1f}g"
+    }
+    
+    # Dietary inferences based on nutritional values
+    suitable_for_diet = []
+    if recipe.total_calories < 400:
+        suitable_for_diet.append("https://schema.org/LowCalorieDiet")
+    if recipe.total_fat < 10:
+        suitable_for_diet.append("https://schema.org/LowFatDiet")
+    
+    # Build keywords from post title and price category
+    keywords = []
+    # Extract words from title (lowercase, filter out short words)
+    title_words = [word.lower() for word in recipe.post.title.split() if len(word) > 2]
+    keywords.extend(title_words)
+    
+    # Add price category as keyword if available
+    if recipe.price_category:
+        # Map price category symbols to readable keywords
+        price_mapping = {
+            "₺": "budget",
+            "₺ ₺": "moderate",
+            "₺ ₺₺": "premium"
+        }
+        price_keyword = price_mapping.get(recipe.price_category, recipe.price_category.lower())
+        keywords.append(price_keyword)
+    
+    # Build the Schema.org Recipe JSON-LD
+    schema_data = {
+        "@context": "https://schema.org",
+        "@type": "Recipe",
+        "name": recipe.post.title,
+        "author": recipe.post.author.username if recipe.post.author else "Unknown",
+        "datePublished": recipe.post.created_at.isoformat(),
+        "dateModified": recipe.updated_at.isoformat(),
+        "description": recipe.post.body[:500] if recipe.post.body else "",
+        "recipeInstructions": recipe.instructions,
+        "recipeIngredient": recipe_ingredients,
+        "nutrition": nutrition
+    }
+    
+    # Add optional fields only if data exists
+    if suitable_for_diet:
+        schema_data["suitableForDiet"] = suitable_for_diet
+    
+    if keywords:
+        schema_data["keywords"] = keywords
+    
+    # Add estimatedCost if available
+    if recipe.total_cost:
+        schema_data["estimatedCost"] = {
+            "@type": "MonetaryAmount",
+            "value": str(recipe.total_cost),
+            "currency": recipe.currency
+        }
+    
+    # Add recipeCategory if tags exist
+    tags = recipe.post.tags.all()
+    if tags:
+        # Use the first tag as recipe category
+        schema_data["recipeCategory"] = tags[0].name
+    
+    return JsonResponse(schema_data)
+


### PR DESCRIPTION
Summary

Adds a new API endpoint that returns Schema.org–compatible JSON-LD recipe data for external integrations.

Example
curl "http://localhost:8080/api/forum/recipe/2/schema/" | python3 -m json.tool

{
  "@context": "https://schema.org",
  "@type": "Recipe",
  "name": "My recipe",
  "author": "Berkay123.",
  "datePublished": "2025-12-14T13:13:56.016969+00:00",
  "dateModified": "2025-12-14T13:13:56.059443+00:00",
  "description": "Its delciiosu",
  "recipeInstructions": "1. do this\n2. do that\n3. wash",
  "recipeIngredient": [
    "0.0g of Tomatoes, raw",
    "0.0g of Egg burrito",
    "0.0g of Water, NFS"
  ],
  "nutrition": {
    "@type": "NutritionInformation",
    "calories": "269.0 calories",
    "proteinContent": "11.9g",
    "fatContent": "14.2g",
    "carbohydrateContent": "24.1g"
  },
  "suitableForDiet": [
    "https://schema.org/LowCalorieDiet"
  ],
  "keywords": [
    "recipe",
    "moderate"
  ],
  "recipeCategory": "Recipe"
}


Closes #789