### PR TITLE
fix: micronutrients daily log uses the wrong key

### DIFF
--- a/frontend/src/pages/NutritionTracking.tsx
+++ b/frontend/src/pages/NutritionTracking.tsx
@@ -317,8 +317,8 @@ const NutritionTrackingPage = () => {
                                       {minerals.map(([key, target]) => {
                                         const name = extractName(key);
                                         const unit = extractUnit(key);
-                                        const currentValue = typeof logMicronutrients[key] === 'number' 
-                                          ? logMicronutrients[key] 
+                                        const currentValue = typeof logMicronutrients[name] === 'number' 
+                                          ? logMicronutrients[name] 
                                           : 0;
                                         let targetValue = 0;
                                         if (typeof target === 'number') {


### PR DESCRIPTION
This originates from my micronutrients normalization pr, front still uses the micronutrient + unit as key instead of micronutrient name. 

Close #808