### PR TITLE
feat: implement private food management with CRUD operations and UI integration

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,7 @@ function App() {
               <Route path="home" element={<Home />} />
               <Route path="foods" element={<Foods />} />
               <Route path="foods/propose" element={<ProposeNewFood />} />
+              <Route path="/foods/private/:id/edit" element={<ProposeNewFood />} />
               <Route path="foods/compare" element={<FoodCompare />} />
               <Route path="forum" element={<Forum />} />
               <Route path="forum/post/:postId" element={<PostDetail />} />

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -55,6 +55,7 @@ export interface FoodProposal {
   price_unit?: PriceUnit;
   currency?: string;
   micronutrients?: { [key: string]: number };
+  isPrivate ?: boolean;
 }
 
 export interface FoodProposalStatus {
@@ -432,10 +433,36 @@ export const apiClient = {
       body: JSON.stringify(proposal),
     }, true),
 
-    getFoodProposals: () =>
+    proposePrivateFood: (proposal: FoodProposal) =>
+    fetchJson<FoodProposalResponse>("/foods/private/", {
+      method: "POST",
+      body: JSON.stringify(proposal),
+    }, true),
+
+  getFoodProposals: () =>
     fetchJson<FoodProposalStatus[]>("/foods/get-proposal-status/", {
       method: "GET",
     }, true),
+  
+  getPrivateFoods: () =>
+    fetchJson<Food[]>("/foods/private/", {
+      method: "GET",
+    }, true),
+  getPrivateFood: (id: number | number) => 
+   fetchJson<Food>(`/foods/private/${id}/`, {
+      method: "GET",
+    }, true),
+  deletePrivateFood: (id: number) =>
+    fetchJson<void>(`/foods/private/${id}/`, {
+      method: "DELETE",
+    }, true),
+
+  updatePrivateFood: (id: number, updateData: Partial<FoodProposal>) =>
+    fetchJson<Food>(`/foods/private/${id}/`, {
+      method: "PATCH",
+      body: JSON.stringify(updateData),
+    }, true),
+
   getAvailableMicronutrients: () =>
     fetchJson<{
       micronutrients: Array<{ name: string; unit: string }>;

--- a/frontend/src/pages/foods/FoodDetail.tsx
+++ b/frontend/src/pages/foods/FoodDetail.tsx
@@ -7,9 +7,10 @@ interface FoodDetailProps {
   food: Food | null;
   open: boolean;
   onClose: () => void;
+  actions?: React.ReactNode;
 }
 
-const FoodDetail: React.FC<FoodDetailProps> = ({ food, open, onClose }) => {
+const FoodDetail: React.FC<FoodDetailProps> = ({ food, open, onClose, actions }) => {
   const [showRecommendations, setShowRecommendations] = useState(false);
   const [selectedNutrient, setSelectedNutrient] = useState<string | null>(null);
   const [recommendations, setRecommendations] = useState<{
@@ -304,6 +305,8 @@ const FoodDetail: React.FC<FoodDetailProps> = ({ food, open, onClose }) => {
           {/* Food title */}
           <h2 className="flex-1 text-xl md:text-2xl font-bold text-[var(--color-text-primary)]">{food.name}</h2>
 
+          {/* Optional actions (edit/delete) */}
+          {actions}
           {/* Close button */}
           <button 
             onClick={onClose}

--- a/frontend/src/pages/foods/PrivateFoodDetail.tsx
+++ b/frontend/src/pages/foods/PrivateFoodDetail.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { PencilSimple, Trash } from '@phosphor-icons/react';
+import FoodDetail from './FoodDetail';
+import { Food, apiClient } from '../../lib/apiClient';
+import { useNavigate } from 'react-router-dom';
+
+interface PrivateFoodDetailProps {
+  food: Food | null;
+  open: boolean;
+  onClose: () => void;
+  onChanged?: () => void;
+}
+
+const PrivateFoodDetail: React.FC<PrivateFoodDetailProps> = ({
+  food,
+  open,
+  onClose,
+  onChanged,
+}) => {
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  if (!food) return null;
+
+  const handleDelete = async () => {
+    if (!confirm(`Delete "${food.name}"? This action cannot be undone.`)) return;
+
+    setLoading(true);
+    try {
+      await apiClient.deletePrivateFood(food.id);
+      onChanged?.();
+      onClose();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <FoodDetail
+      food={food}
+      open={open}
+      onClose={onClose}
+      actions={
+        <>
+          <button
+            onClick={() => {
+              navigate(`/foods/private/${food.id}/edit`);
+            }
+            }
+            disabled={loading}
+            className="p-2 rounded-full bg-blue-500 hover:bg-blue-600 text-white"
+            title="Edit food"
+          >
+            <PencilSimple size={18} weight="bold" />
+          </button>
+
+          <button
+            onClick={handleDelete}
+            disabled={loading}
+            className="p-2 rounded-full bg-red-500 hover:bg-red-600 text-white"
+            title="Delete food"
+          >
+            <Trash size={18} weight="bold" />
+          </button>
+        </>
+      }
+    />
+  );
+};
+
+
+export default PrivateFoodDetail;


### PR DESCRIPTION
## Private Food Visibility and Management

Introduce **private food support** by extending the food proposal flow with visibility control and adding private food management to the Profile page.

### Frontend Changes
- Added **Visibility (Private/Public)** checkbox to the food proposal form
  - Public foods follow the existing proposal & review flow
  - Private foods are saved only for the user
- Added **Private Foods** tab to the Profile page
  - Displays a list of user-created private foods
- Enabled **edit and delete** actions for private foods
  - Editing reuses the existing food proposal form with pre-filled data
  - Deletion includes confirmation and immediate list refresh
- Reused and extended `FoodDetail` with action slots for private food controls

### UX Improvements
- Unified create/edit flow for foods using a single form
- Clear separation between public proposals and private foods
- No changes to existing public proposal behavior

closes #807
