### PR TITLE
fix(mobile): Fix feed loading race condition on startup

### DIFF
--- a/mobile/nutrihub/src/screens/HomeScreen.tsx
+++ b/mobile/nutrihub/src/screens/HomeScreen.tsx
@@ -41,7 +41,7 @@ const HomeScreen: React.FC = () => {
   const { user } = useAuth();
   
   const [feedPosts, setFeedPosts] = useState<ForumTopic[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);


### PR DESCRIPTION
## 🐛 Fix: Error fetching feed on startup

**Closes #817**

### 📝 Description

Fixes the "Error fetching feed: Error: Invalid page" error that occurs on the Home screen when the app starts up.

### 🎯 Root Cause

A race condition in [HomeScreen.tsx](cci:7://file:///c:/sweWorkspace/bounswe2025group9/mobile/nutrihub/src/screens/HomeScreen.tsx:0:0-0:0) where the `loading` state was incorrectly initialized as `false`. This caused the `FlatList`'s `onEndReached` callback to trigger [handleLoadMore()](cci:1://file:///c:/sweWorkspace/bounswe2025group9/mobile/nutrihub/src/screens/forum/FeedScreen.tsx:130:2-138:4) immediately on mount, requesting **page 2** before **page 1** had been fetched. The backend correctly returned a 404 "Invalid page" error.

### ✅ Changes Made

- **File:** [mobile/nutrihub/src/screens/HomeScreen.tsx](cci:7://file:///c:/sweWorkspace/bounswe2025group9/mobile/nutrihub/src/screens/HomeScreen.tsx:0:0-0:0)
- **Change:** Initialize `loading` state to `true` instead of `false` (line 44)

```diff
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);

