### PR TITLE
feat: handle deletion of private food with error handling for protected records

### DIFF
--- a/backend/foods/views.py
+++ b/backend/foods/views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import render, get_object_or_404
+from django.db.models.deletion import ProtectedError
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from foods.models import (
@@ -725,7 +726,19 @@ class PrivateFoodView(APIView):
             createdBy=request.user,
             validated=False,
         )
-        food.delete()
+        try:
+            food.delete()
+        except ProtectedError:
+            return Response(
+                {
+                    "detail": (
+                        "This food cannot be deleted because it is currently "
+                        "used in your nutrition tracker or another record."
+                    )
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+
         return Response(status=status.HTTP_204_NO_CONTENT)
     
 

--- a/frontend/src/pages/foods/PrivateFoodDetail.tsx
+++ b/frontend/src/pages/foods/PrivateFoodDetail.tsx
@@ -26,11 +26,27 @@ const PrivateFoodDetail: React.FC<PrivateFoodDetailProps> = ({
     if (!confirm(`Delete "${food.name}"? This action cannot be undone.`)) return;
 
     setLoading(true);
+
     try {
       await apiClient.deletePrivateFood(food.id);
+    }
+    catch (error: any) {
+      const status = error?.status;
+      const message = error?.data?.detail;
+
+      if (status === 409) {
+        alert(
+          message ||
+            "This food cannot be deleted because it is currently in use."
+        );
+        return;
+      }
+
+      alert("Failed to delete food. Please try again later.");
+    } 
+    finally {
       onChanged?.();
       onClose();
-    } finally {
       setLoading(false);
     }
   };


### PR DESCRIPTION

Handle private food deletion when private food is used somewhere else.

Proper error messages are returned both in backend and frontend. 


fixes #815 