### PR TITLE
Meal Planner Bug Fix

### DIFF
--- a/backend/meal_planner/serializers.py
+++ b/backend/meal_planner/serializers.py
@@ -30,7 +30,8 @@ class MealPlanCreateSerializer(serializers.ModelSerializer):
     
     class Meta:
         model = MealPlan
-        fields = ['name', 'meals']
+        fields = ['id', 'name', 'meals']
+        read_only_fields = ['id']
     
     def create(self, validated_data):
         meals_data = validated_data.pop('meals', [])

--- a/frontend/src/pages/mealplanner/MealPlanner.tsx
+++ b/frontend/src/pages/mealplanner/MealPlanner.tsx
@@ -293,6 +293,9 @@ const MealPlanner = ({
 
         try {
             const newPlan = await apiClient.createMealPlan(mealPlanData);
+            if (!newPlan || typeof newPlan.id !== 'number') {
+                throw new Error('Meal plan response is missing an identifier.');
+            }
             console.log('Meal plan created:', newPlan);
             setSavedMealPlanId(newPlan.id);
             await apiClient.setCurrentMealPlan(newPlan.id);
@@ -372,6 +375,9 @@ const MealPlanner = ({
                 };
                 
                 const newPlan = await apiClient.createMealPlan(mealPlanData);
+                if (!newPlan || typeof newPlan.id !== 'number') {
+                    throw new Error('Meal plan response is missing an identifier.');
+                }
                 setSavedMealPlanId(newPlan.id);
                 await apiClient.setCurrentMealPlan(newPlan.id);
                 // Now log it


### PR DESCRIPTION
## Summary
- include the meal plan’s `id` in `MealPlanCreateSerializer` responses so the frontend can immediately mark new plans as current
- guard the Meal Planner save/log handlers against missing IDs before calling `/set-current/`, ensuring all follow‑up requests use a valid `/meal-planner/<id>/…` path

## Testing
- python3 manage.py test meal_planner