### PR TITLE
Automated Swagger Doc Generation 

### DIFF
--- a/backend/foods/schemas.py
+++ b/backend/foods/schemas.py
@@ -1,0 +1,153 @@
+"""
+OpenAPI schema examples and serializers for Foods app endpoints.
+These are used to enhance Swagger documentation with request/response examples.
+"""
+
+from rest_framework import serializers
+from drf_spectacular.utils import OpenApiExample
+
+
+# Request serializers for documentation
+class FoodSearchRequestSerializer(serializers.Serializer):
+    """Request body for POST /api/foods/ - Advanced food search and filtering"""
+    
+    search = serializers.CharField(
+        required=False,
+        help_text="Search term to filter foods by name (case-insensitive)",
+        allow_blank=True
+    )
+    category = serializers.CharField(
+        required=False,
+        help_text="Comma-separated list of categories (e.g., 'Vegetables,Fruits')",
+        allow_blank=True
+    )
+    sort_by = serializers.CharField(
+        required=False,
+        help_text="Field to sort by: nutrition-score, protein, carbohydrate, fat, price, cost-nutrition-ratio, name",
+        allow_blank=True
+    )
+    order = serializers.ChoiceField(
+        choices=['asc', 'desc'],
+        required=False,
+        help_text="Sort order: asc or desc (default: desc)"
+    )
+    micronutrients = serializers.ListField(
+        child=serializers.DictField(),
+        required=False,
+        help_text="List of micronutrient filters with min/max values"
+    )
+
+
+class MicronutrientFilterSerializer(serializers.Serializer):
+    """Micronutrient filter specification"""
+    
+    Micronutrient = serializers.CharField(
+        help_text="Micronutrient name (e.g., 'Iron', 'Vitamin C')"
+    )
+    MinValue = serializers.ListField(
+        child=serializers.FloatField(),
+        required=False,
+        help_text="Minimum value (per specified grams)"
+    )
+    MaxValue = serializers.ListField(
+        child=serializers.FloatField(),
+        required=False,
+        help_text="Maximum value (per specified grams)"
+    )
+    PerHowmanyGrams = serializers.CharField(
+        default="100 gr",
+        help_text="Amount in grams (e.g., '100 gr', '150 gr')"
+    )
+
+
+# OpenAPI Examples
+FOOD_SEARCH_EXAMPLES = [
+    OpenApiExample(
+        "Basic Search",
+        summary="Simple search by name",
+        description="Search for foods containing 'apple' in their name",
+        value={
+            "search": "apple",
+            "sort_by": "nutrition-score",
+            "order": "desc"
+        },
+        request_only=True,
+    ),
+    OpenApiExample(
+        "Category Filter",
+        summary="Filter by categories",
+        description="Get all fruits and vegetables",
+        value={
+            "category": "Fruits,Vegetables",
+            "sort_by": "name",
+            "order": "asc"
+        },
+        request_only=True,
+    ),
+    OpenApiExample(
+        "Micronutrient Filter",
+        summary="Filter by micronutrients",
+        description="Find foods high in iron and vitamin C",
+        value={
+            "search": "",
+            "micronutrients": [
+                {
+                    "Micronutrient": "Iron",
+                    "MinValue": [3.0],
+                    "MaxValue": [],
+                    "PerHowmanyGrams": "100 gr"
+                },
+                {
+                    "Micronutrient": "Vitamin C",
+                    "MinValue": [20.0],
+                    "MaxValue": [],
+                    "PerHowmanyGrams": "100 gr"
+                }
+            ],
+            "sort_by": "nutrition-score",
+            "order": "desc"
+        },
+        request_only=True,
+    ),
+    OpenApiExample(
+        "Cost Optimization",
+        summary="Find best cost-nutrition ratio",
+        description="Sort foods by cost efficiency (price per nutrition score)",
+        value={
+            "category": "Vegetables,Grains",
+            "sort_by": "cost-nutrition-ratio",
+            "order": "asc"
+        },
+        request_only=True,
+    ),
+]
+
+
+PRIVATE_FOOD_CREATE_EXAMPLE = OpenApiExample(
+    "Create Private Food",
+    summary="Create a new private food entry",
+    description="Create a custom food item visible only to you",
+    value={
+        "name": "My Custom Protein Shake",
+        "category": "Beverages",
+        "servingSize": "250 ml",
+        "calories": 200,
+        "proteinContent": 25.0,
+        "carbohydrateContent": 15.0,
+        "fatContent": 3.0,
+        "nutritionScore": 85,
+        "description": "Homemade protein shake recipe"
+    },
+    request_only=True,
+)
+
+
+FOOD_PROPOSAL_EXAMPLE = OpenApiExample(
+    "Submit Food Proposal",
+    summary="Submit private food for validation",
+    description="Request moderator approval for a private food to make it public",
+    value={
+        "food_entry_id": 123
+    },
+    request_only=True,
+)

--- a/backend/foods/views.py
+++ b/backend/foods/views.py
@@ -44,6 +44,15 @@ from rest_framework.exceptions import PermissionDenied
 from django.utils import timezone
 import re
 
+# OpenAPI documentation imports
+from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiExample, extend_schema_view
+from foods.schemas import (
+    FoodSearchRequestSerializer,
+    FOOD_SEARCH_EXAMPLES,
+    PRIVATE_FOOD_CREATE_EXAMPLE,
+    FOOD_PROPOSAL_EXAMPLE,
+)
+
 sys.path.append(
     os.path.join(os.path.dirname(__file__), "..", "api", "db_initialization")
 )
@@ -65,7 +74,63 @@ _image_cache_executor = ThreadPoolExecutor(
 )
 
 
+
+
+@extend_schema_view(
+    get=extend_schema(
+        tags=["foods"],
+        summary="List and search foods",
+        description="Retrieve foods with advanced filtering capabilities including search, category filtering, "
+                    "micronutrient range filtering, and sorting. Supports pagination.",
+        parameters=[
+            OpenApiParameter(
+                name="search",
+                description="Search term to filter foods by name (case-insensitive)",
+                required=False,
+                type=str
+            ),
+            OpenApiParameter(
+                name="category",
+                description="Comma-separated list of categories (e.g., 'Vegetables,Fruits')",
+                required=False,
+                type=str
+            ),
+            OpenApiParameter(
+                name="micronutrient",
+                description="Micronutrient range filtering. Format: name:low-high (e.g., 'iron:3-10,vitamin c:20-'). "
+                           "Supports: name:low-high (bounded), name:low- (minimum), name:-high (maximum)",
+                required=False,
+                type=str
+            ),
+            OpenApiParameter(
+                name="sort_by",
+                description="Field to sort by",
+                required=False,
+                type=str,
+                enum=["nutrition-score", "protein", "carbohydrate", "fat", "price", "cost-nutrition-ratio", "name"]
+            ),
+            OpenApiParameter(
+                name="order",
+                description="Sort order",
+                required=False,
+                type=str,
+                enum=["asc", "desc"]
+            ),
+        ],
+        responses={200: FoodEntrySerializer(many=True)},
+    ),
+    post=extend_schema(
+        tags=["foods"],
+        summary="Advanced food search (POST)",
+        description="Advanced food search with micronutrient filtering via POST body. "
+                    "Supports all GET parameters plus structured micronutrient filters.",
+        request=FoodSearchRequestSerializer,
+        responses={200: FoodEntrySerializer(many=True)},
+        examples=FOOD_SEARCH_EXAMPLES,
+    ),
+)
 class FoodCatalog(ListAPIView):
+
     permission_classes = [AllowAny]
     serializer_class = FoodEntrySerializer
 
@@ -632,6 +697,7 @@ class FoodCatalog(ListAPIView):
         return Response(data)
 
 
+@extend_schema(tags=["foods"])
 class PrivateFoodView(APIView):
     """
     CRUD for user's private foods.
@@ -648,6 +714,11 @@ class PrivateFoodView(APIView):
     # ------------------------
     # GET (LIST / RETRIEVE)
     # ------------------------
+    @extend_schema(
+        summary="List or retrieve private foods",
+        description="Get all private foods for the authenticated user, or retrieve a specific private food by ID",
+        responses={200: FoodEntrySerializer(many=True)}
+    )
     def get(self, request, pk=None):
         user = request.user
 
@@ -674,6 +745,13 @@ class PrivateFoodView(APIView):
     # ------------------------
     # POST (CREATE)
     # ------------------------
+    @extend_schema(
+        summary="Create private food",
+        description="Create a new private food entry visible only to you",
+        request=FoodEntrySerializer,
+        responses={201: FoodEntrySerializer},
+        examples=[PRIVATE_FOOD_CREATE_EXAMPLE]
+    )
     def post(self, request):
         serializer = FoodEntrySerializer(data=request.data, context={'request': request})
 
@@ -765,6 +843,7 @@ class AvailableMicronutrientsView(APIView):
         }, status=status.HTTP_200_OK)
 
 
+@extend_schema(tags=["foods"])
 @permission_classes([IsAuthenticated])
 class FoodProposalSubmitView(APIView):
     """
@@ -778,6 +857,13 @@ class FoodProposalSubmitView(APIView):
     - Private (validated=False)
     - Not already proposed
     """
+    @extend_schema(
+        summary="Submit food for approval",
+        description="Submit a private food entry for moderator approval to make it public",
+        request=FoodProposalSerializer,
+        responses={201: FoodProposalSerializer},
+        examples=[FOOD_PROPOSAL_EXAMPLE]
+    )
     def post(self, request):
         serializer = FoodProposalSerializer(data=request.data, context={'request': request})
         if serializer.is_valid():
@@ -785,6 +871,11 @@ class FoodProposalSubmitView(APIView):
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
     
+    @extend_schema(
+        summary="Get my food proposals",
+        description="List all food proposals submitted by the authenticated user",
+        responses={200: FoodProposalStatusSerializer(many=True)}
+    )
     def get(self, request):
         proposals = FoodProposal.objects.filter(proposedBy=request.user).order_by('-createdAt')
         serializer = FoodProposalStatusSerializer(proposals, many=True)

--- a/backend/project/settings.py
+++ b/backend/project/settings.py
@@ -58,6 +58,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "rest_framework_simplejwt.token_blacklist",
     "rest_framework_simplejwt",
+    "drf_spectacular",
     "accounts",
     "api",
     "foods",
@@ -173,6 +174,7 @@ REST_FRAMEWORK = {
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 12,
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }
 
 SIMPLE_JWT = {
@@ -215,3 +217,40 @@ CORS_ALLOW_CREDENTIALS = True
 DEEPL_API_KEY = os.environ.get(
     "DEEPL_API_KEY", "7225230f-59a5-42eb-b576-7fb2d5cf2db1:fx"
 )
+
+# drf-spectacular settings for OpenAPI/Swagger documentation
+SPECTACULAR_SETTINGS = {
+    "TITLE": "NutriHub API",
+    "DESCRIPTION": "Comprehensive nutrition tracking and food community platform API. "
+                   "Features include food catalog with micronutrient filtering, "
+                   "meal planning, nutrition logging, community forum with recipes, "
+                   "and user profile management.",
+    "VERSION": "1.0.0",
+    "SERVE_INCLUDE_SCHEMA": False,
+    "COMPONENT_SPLIT_REQUEST": True,
+    "SCHEMA_PATH_PREFIX": r"/api/",
+    "SERVERS": [
+        {"url": "https://nutrihub.fit", "description": "Production server"},
+        {"url": "http://localhost:8080", "description": "Development server"},
+    ],
+    "TAGS": [
+        {"name": "authentication", "description": "User authentication and registration"},
+        {"name": "users", "description": "User profile management"},
+        {"name": "foods", "description": "Food catalog and nutrition data"},
+        {"name": "forum", "description": "Community posts, recipes, and comments"},
+        {"name": "meal-planner", "description": "Meal planning and nutrition tracking"},
+    ],
+    "APPEND_COMPONENTS": {
+        "securitySchemes": {
+            "jwtAuth": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT",
+                "description": "JWT token authentication. Obtain token via /api/users/token/ endpoint."
+            }
+        }
+    },
+    "SECURITY": [{"jwtAuth": []}],
+    "PREPROCESSING_HOOKS": [],
+    "POSTPROCESSING_HOOKS": [],
+}

--- a/backend/project/urls.py
+++ b/backend/project/urls.py
@@ -17,9 +17,14 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import include, path
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 urlpatterns = [
     path("api/admin/", admin.site.urls),
+    # OpenAPI schema and documentation
+    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path("api/docs/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
+    # API endpoints
     path("api/", include("api.urls")),
     path("api/users/", include("accounts.urls")),
     path("api/users/", include("django.contrib.auth.urls")),

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,4 @@ Pillow>=10.0.0
 gunicorn
 whitenoise
 Pillow
+drf-spectacular>=0.27.0


### PR DESCRIPTION
Adds automated Swagger/OpenAPI documentation generation to the project, ensuring API specs stay in sync with the codebase. This PR demonstrates the setup using more complex endpoints such as GET /api/forum/posts and GET /api/foods, highlighting support for query parameters, nested response schemas, and collection responses.
Endpoint is available at : http://localhost:8080/api/docs/

fixes #835 