### PR TITLE
Fix/header size

### DIFF
--- a/mobile/nutrihub/src/screens/food/FoodScreen.tsx
+++ b/mobile/nutrihub/src/screens/food/FoodScreen.tsx
@@ -897,18 +897,19 @@ const styles = StyleSheet.create({
   headerTop: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     marginBottom: SPACING.md,
   },
   headerTitle: {
     flex: 1,
   },
   headerButtons: {
-    flexDirection: 'row',
-    gap: SPACING.sm,
+    flexDirection: 'column',
+    gap: SPACING.xs,
+    alignItems: 'flex-end',
   },
   compareButton: {
-    marginRight: SPACING.xs,
+    marginRight: 0,
   },
   searchContainer: {
     flexDirection: 'row',


### PR DESCRIPTION
closes #844 

the alignment issue is corrected in the food catolog screen

Food catolog used to be displayed like this
<img width="436" height="173" alt="image" src="https://github.com/user-attachments/assets/e100908e-96f8-4b4c-b534-dbf58721e7ed" />


now it is displayed like that:
![Food Catalog](https://github.com/user-attachments/assets/8fa9713d-290f-42a6-86a1-11f46df6fd4b)
