### PR TITLE
Fix/840 search behavior in mobile food catolog

### DIFF
--- a/mobile/nutrihub/src/screens/food/FoodScreen.tsx
+++ b/mobile/nutrihub/src/screens/food/FoodScreen.tsx
@@ -254,6 +254,8 @@ const FoodScreen: React.FC = () => {
       if (response.error) {
         console.error('API Error:', response.error);
         setError(response.error);
+        // Stop processing - don't continue with invalid data
+        setPagination(prev => ({ ...prev, loading: false }));
         return;
       }
 

--- a/mobile/nutrihub/src/services/api/food.service.ts
+++ b/mobile/nutrihub/src/services/api/food.service.ts
@@ -209,6 +209,22 @@ export const getFoodCatalog = async (
     const response = await apiClient.get<ApiPaginatedResponse<ApiFoodItem>>(fullUrl);
 
     if (response.error) {
+      // Special handling for pagination 404 errors
+      // When requesting pages beyond available results, backend returns 404 "Invalid page"
+      // This should be treated as "no more results" rather than a fatal error
+      if (response.status === 404 && 
+          (response.error.toLowerCase().includes('invalid page') || 
+           response.error.toLowerCase().includes('page'))) {
+        console.log('No more pages available (404), treating as end of results');
+        return {
+          data: [],
+          status: 200, // Return success status
+          hasMore: false,
+          total: 0
+        };
+      }
+      
+      // For other errors, return the error as before
       console.error('API error:', response.error);
       return {
         error: response.error,


### PR DESCRIPTION
**Fix mobile food catalog pagination 404 error**

Gracefully handle backend's 404 "Invalid page" response when requesting pages beyond available results. Treats pagination 404s as "no more results" instead of displaying errors to users.
**Changes:**
- food.service.ts: Detect pagination 404s and return empty array with hasMore: false
- FoodScreen.tsx: Add early return on errors to prevent invalid data processing


fixes #840 