### PR TITLE
Fix mobile food proposal required field validation UX

### DIFF
--- a/mobile/nutrihub/src/components/food/ProposeFoodModal.tsx
+++ b/mobile/nutrihub/src/components/food/ProposeFoodModal.tsx
@@ -174,6 +174,8 @@ const ProposeFoodModal: React.FC<ProposeFoodModalProps> = ({
       micronutrients: {},
     },
     validationRules,
+    // Re-validate as user types so "required" errors clear immediately
+    validateOnChange: true,
     onSubmit: async (formValues) => {
       const submitData = {
         ...formValues,

--- a/mobile/nutrihub/src/hooks/useForm.ts
+++ b/mobile/nutrihub/src/hooks/useForm.ts
@@ -178,13 +178,7 @@ function useForm<T extends Record<string, any>>({
       ...prevValues,
       [name]: value,
     }));
-    
-    // Mark field as touched
-    setTouched((prevTouched) => ({
-      ...prevTouched,
-      [name]: true,
-    }));
-    
+
     // Validate field on change if enabled
     if (validateOnChange) {
       const error = validateField(name, value);


### PR DESCRIPTION
## Summary
- validate food proposal inputs on change so required errors clear as soon as valid text is entered
- avoid marking fields as touched on every keystroke to prevent premature required messages while typing

Closes #863

## Testing
- not run (not requested)