### PR TITLE
fix the 0 valued info page when adding private food to nutrition trac…

### DIFF
--- a/mobile/nutrihub/src/services/api/privateFood.service.ts
+++ b/mobile/nutrihub/src/services/api/privateFood.service.ts
@@ -42,10 +42,11 @@ const normalizePrivateFood = (data: any): PrivateFood => {
             data.serving_size_in_grams ??
             100
         ),
-        calories: Number(data.calories_per_serving ?? data.calories ?? data.energy ?? 0),
-        protein: Number(data.protein_content ?? data.protein ?? 0),
-        carbohydrates: Number(data.carbohydrate_content ?? data.carbohydrates ?? 0),
-        fat: Number(data.fat_content ?? data.fat ?? 0),
+        // Handle both snake_case and camelCase field names from API
+        calories: Number(data.calories_per_serving ?? data.caloriesPerServing ?? data.calories ?? data.energy ?? 0),
+        protein: Number(data.protein_content ?? data.proteinContent ?? data.protein ?? 0),
+        carbohydrates: Number(data.carbohydrate_content ?? data.carbohydrateContent ?? data.carbohydrates ?? 0),
+        fat: Number(data.fat_content ?? data.fatContent ?? data.fat ?? 0),
         fiber: data.fiber !== undefined ? Number(data.fiber) : undefined,
         sugar: data.sugar !== undefined ? Number(data.sugar) : undefined,
         micronutrients: data.micronutrients ?? undefined,


### PR DESCRIPTION
the nutrition values now are shown correctly when adding a private food to a meal from nutrition tracking page
All is yours 

<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/a8f4f430-382d-4358-85ef-9f5a8ca6ff3e" />
